### PR TITLE
Fix types NavItem and SharedData

### DIFF
--- a/resources/js/components/NavMain.vue
+++ b/resources/js/components/NavMain.vue
@@ -2,13 +2,7 @@
 import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
-import type { Component } from 'vue';
-
-interface NavItem {
-    title: string;
-    url: string;
-    icon: Component;
-}
+import { type NavItem } from '@/types';
 
 defineProps<{
     items: NavItem[];

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -8,15 +8,15 @@ import { Link } from '@inertiajs/vue3';
 const sidebarNavItems: NavItem[] = [
     {
         title: 'Profile',
-        href: '/settings/profile',
+        url: '/settings/profile',
     },
     {
         title: 'Password',
-        href: '/settings/password',
+        url: '/settings/password',
     },
     {
         title: 'Appearance',
-        href: '/settings/appearance',
+        url: '/settings/appearance',
     },
 ];
 
@@ -32,12 +32,12 @@ const currentPath = window.location.pathname;
                 <nav class="flex flex-col space-x-0 space-y-1">
                     <Button
                         v-for="item in sidebarNavItems"
-                        :key="item.href"
+                        :key="item.url"
                         variant="ghost"
-                        :class="['w-full justify-start', { 'bg-muted': currentPath === item.href }]"
+                        :class="['w-full justify-start', { 'bg-muted': currentPath === item.url }]"
                         as-child
                     >
-                        <Link :href="item.href">
+                        <Link :href="item.url">
                             {{ item.title }}
                         </Link>
                     </Button>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from 'lucide-vue-next';
+import type { PageProps } from "@inertiajs/core";
 
 export interface Auth {
     user: User;
@@ -11,12 +12,12 @@ export interface BreadcrumbItem {
 
 export interface NavItem {
     title: string;
-    href: string;
+    url: string;
     icon?: LucideIcon;
     isActive?: boolean;
 }
 
-export interface SharedData {
+export interface SharedData extends PageProps {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;


### PR DESCRIPTION
I found several type-checking issues with `NavItem` and `SharedData`.

In some files, we were using `NavItem['href']`, while in others, we were using `NavItem['url']`. Additionally, there was a local `NavItem` that differed from the global `NavItem` in types, with one using `href` and the other using `url`.

With this PR, the issue now seems to be fixed.