### PR TITLE
fixing the warning message

### DIFF
--- a/resources/js/components/AppearanceTabs.vue
+++ b/resources/js/components/AppearanceTabs.vue
@@ -6,9 +6,7 @@ interface Props {
     class?: string;
 }
 
-const { class: containerClass } = withDefaults(defineProps<Props>(), {
-    class: '',
-});
+const { class: containerClass = '' } = defineProps<Props>();
 
 const { appearance, updateAppearance } = useAppearance();
 


### PR DESCRIPTION
When running `npm run build` or `npm run dev`, we are getting this warning:

```
npm run build                                                                                   ✔  01:04:13 PM 

> build
> vite build

vite v6.1.1 building for production...
transforming (1460) node_modules/lucide-vue-next/dist/esm/icons/sunset.js[@vue/compiler-sfc] withDefaults() is unnecessary when using destructure with defineProps().
Reactive destructure will be disabled when using withDefaults().
Prefer using destructure default values, e.g. const { foo = 1 } = defineProps(...).

/Users/tony/Herd/vue-starter-kit/resources/js/components/AppearanceTabs.vue
7  |  }
8  |
9  |  const { class: containerClass } = withDefaults(defineProps<Props>(), {
   |                                    ^^^^^^^^^^^^
10 |      class: '',
11 |  });
```

This PR will fix that warning by removing the unnecessary withDefaults().