### PR TITLE
Remove redundant prop sharing from the middleware

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,13 +38,13 @@ class HandleInertiaRequests extends Middleware
     {
         [$message, $author] = str(Inspiring::quotes()->random())->explode('-');
 
-        return array_merge(parent::share($request), [
+        return [
             ...parent::share($request),
             'name' => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
                 'user' => $request->user(),
             ],
-        ]);
+        ];
     }
 }


### PR DESCRIPTION
I am not sure why `array_merge()` is used with the array spread operator. It may not be necessary. Can't we simply use the array spread operator?



Before
```php
return array_merge(parent::share($request), [
    ...parent::share($request),
    'name' => config('app.name'),
    'quote' => ['message' => trim($message), 'author' => trim($author)],
    'auth' => [
        'user' => $request->user(),
    ],
]);
```

After
```php
return [
    ...parent::share($request),
    'name' => config('app.name'),
    'quote' => ['message' => trim($message), 'author' => trim($author)],
    'auth' => [
        'user' => $request->user(),
    ],
];
```