### PR TITLE
fix(ui): add missing cursor-pointer to navigation links

### DIFF
--- a/resources/js/components/UserMenuContent.vue
+++ b/resources/js/components/UserMenuContent.vue
@@ -21,7 +21,7 @@ defineProps<Props>();
     <DropdownMenuSeparator />
     <DropdownMenuGroup>
         <DropdownMenuItem :as-child="true">
-            <Link class="block w-full" :href="route('profile.edit')" as="button">
+            <Link class="block w-full cursor-pointer" :href="route('profile.edit')" as="button">
                 <Settings class="mr-2 h-4 w-4" />
                 Settings
             </Link>
@@ -29,7 +29,7 @@ defineProps<Props>();
     </DropdownMenuGroup>
     <DropdownMenuSeparator />
     <DropdownMenuItem :as-child="true">
-        <Link class="block w-full" method="post" :href="route('logout')" as="button">
+        <Link class="block w-full cursor-pointer" method="post" :href="route('logout')" as="button">
             <LogOut class="mr-2 h-4 w-4" />
             Log out
         </Link>


### PR DESCRIPTION
### Summary
This PR adds the missing cursor-pointer class to the Settings and Log out links in the dropdown menu. Previously, these links did not visually indicate interactivity, which could lead to a slightly confusing user experience.

### Changes
Added cursor-pointer to both <Link> components inside the dropdown menu.
Ensured consistency with other interactive elements in the UI.

### Why This Fix?
Without cursor-pointer, users may not realize that these links are clickable, especially since they are styled as buttons. This small update improves usability by aligning with common UI behavior.

### Impact

- Improved user experience by providing a clearer visual cue for interactive elements.
- No breaking changes—only a minor class addition for better styling.

### Testing

- Manually verified that the cursor changes appropriately on hover.
- Checked that the links still function as expected.