### PR TITLE
refactor: Update NavMain.vue to use `item.href` instead of `item.url`

### DIFF
--- a/resources/js/components/NavMain.vue
+++ b/resources/js/components/NavMain.vue
@@ -22,8 +22,8 @@ const page = usePage<SharedData>();
         <SidebarGroupLabel>Platform</SidebarGroupLabel>
         <SidebarMenu>
             <SidebarMenuItem v-for="item in items" :key="item.title">
-                <SidebarMenuButton as-child :is-active="item.url === page.url">
-                    <Link :href="item.url">
+                <SidebarMenuButton as-child :is-active="item.href === page.url">
+                    <Link :href="item.href">
                         <component :is="item.icon" />
                         <span>{{ item.title }}</span>
                     </Link>


### PR DESCRIPTION
The change replaces `item.url` with `item.href` in the NavMain.vue component to align with the updated data structure. This ensures consistency and avoids potential issues with undefined properties. No breaking changes are introduced.