### PR TITLE
Make "Current Password" label consistent with other labels

### DIFF
--- a/resources/js/pages/settings/Password.vue
+++ b/resources/js/pages/settings/Password.vue
@@ -67,7 +67,7 @@ const updatePassword = () => {
 
                 <form @submit.prevent="updatePassword" class="space-y-6">
                     <div class="grid gap-2">
-                        <Label for="current_password">Current Password</Label>
+                        <Label for="current_password">Current password</Label>
                         <Input
                             id="current_password"
                             ref="currentPasswordInput"


### PR DESCRIPTION
**Fix label casing inconsistency in password update form**

Updated the "Current Password" label to use sentence case ("Current password") for consistency with the "New password" and "Confirm password" labels. This ensures a uniform and visually balanced UI.

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/e257e0aa-27f3-41ab-aeb8-858c199ce137" />
