### PR TITLE
Fix: Explicitly Initialize Input Refs with null for Better Type Safety

### DIFF
--- a/resources/js/pages/settings/Password.vue
+++ b/resources/js/pages/settings/Password.vue
@@ -25,8 +25,8 @@ const breadcrumbItems: BreadcrumbItem[] = [
     },
 ];
 
-const passwordInput = ref<HTMLInputElement>();
-const currentPasswordInput = ref<HTMLInputElement>();
+const passwordInput = ref<HTMLInputElement | null>(null);
+const currentPasswordInput = ref<HTMLInputElement | null>(null);
 
 const form = useForm({
     current_password: '',


### PR DESCRIPTION
### Summary  
This PR updates the initialization of `ref<HTMLInputElement>` references by explicitly setting them to `null`.  

### Changes  
- Updated `ref<HTMLInputElement>()` to `ref<HTMLInputElement | null>(null)`, ensuring proper type safety.  
- Prevents potential runtime errors by making sure `passwordInput.value` and `currentPasswordInput.value` are never `undefined`.  
- Aligns with Vue best practices for handling template refs.  

### Why?  
- Without explicit `null`, TypeScript infers `undefined`, leading to potential issues when accessing `.value`.  
- Ensures better predictability and avoids unnecessary runtime checks.  

This change improves overall code reliability and maintainability.