### PR TITLE
Fix: Breadcrumb not displayed on the header layout

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import AppLogo from '@/components/AppLogo.vue';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import Breadcrumbs from '@/components/Breadcrumbs.vue';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import {
@@ -77,7 +77,7 @@ const rightNavItems: NavItem[] = [
                             <SheetHeader class="flex justify-start text-left">
                                 <AppLogoIcon class="size-6 fill-current text-black dark:text-white" />
                             </SheetHeader>
-                            <div class="flex flex-col justify-between h-full space-y-4 py-6 flex-1">
+                            <div class="flex h-full flex-1 flex-col justify-between space-y-4 py-6">
                                 <nav class="-mx-3 space-y-1">
                                     <Link
                                         v-for="item in mainNavItems"

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -19,6 +19,14 @@ import type { BreadcrumbItem, NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
 import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-vue-next';
 import { computed } from 'vue';
+import {
+    Breadcrumb,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator,
+    BreadcrumbItem as BreadcrumbItemComponent
+} from '@/components/ui/breadcrumb';
 
 interface Props {
     breadcrumbs?: BreadcrumbItem[];
@@ -182,7 +190,23 @@ const rightNavItems: NavItem[] = [
 
         <div v-if="props.breadcrumbs.length > 1" class="flex w-full border-b border-sidebar-border/70">
             <div class="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl">
-                <Breadcrumbs :breadcrumbs="breadcrumbs" />
+                <Breadcrumb>
+                    <BreadcrumbList>
+                        <template v-for="(item, index) in breadcrumbs" :key="index">
+                            <BreadcrumbItemComponent>
+                                <template v-if="index === breadcrumbs.length - 1">
+                                    <BreadcrumbPage>{{ item.title }}</BreadcrumbPage>
+                                </template>
+                                <template v-else>
+                                    <BreadcrumbLink :href="item.href">
+                                        {{ item.title }}
+                                    </BreadcrumbLink>
+                                </template>
+                            </BreadcrumbItemComponent>
+                            <BreadcrumbSeparator v-if="index !== breadcrumbs.length - 1" />
+                        </template>
+                    </BreadcrumbList>
+                </Breadcrumb>
             </div>
         </div>
     </div>

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -2,6 +2,7 @@
 import AppLogo from '@/components/AppLogo.vue';
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import Breadcrumbs from '@/components/Breadcrumbs.vue';
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import {
@@ -19,14 +20,6 @@ import type { BreadcrumbItem, NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
 import { BookOpen, Folder, LayoutGrid, Menu, Search } from 'lucide-vue-next';
 import { computed } from 'vue';
-import {
-    Breadcrumb,
-    BreadcrumbLink,
-    BreadcrumbList,
-    BreadcrumbPage,
-    BreadcrumbSeparator,
-    BreadcrumbItem as BreadcrumbItemComponent
-} from '@/components/ui/breadcrumb';
 
 interface Props {
     breadcrumbs?: BreadcrumbItem[];
@@ -190,23 +183,7 @@ const rightNavItems: NavItem[] = [
 
         <div v-if="props.breadcrumbs.length > 1" class="flex w-full border-b border-sidebar-border/70">
             <div class="mx-auto flex h-12 w-full items-center justify-start px-4 text-neutral-500 md:max-w-7xl">
-                <Breadcrumb>
-                    <BreadcrumbList>
-                        <template v-for="(item, index) in breadcrumbs" :key="index">
-                            <BreadcrumbItemComponent>
-                                <template v-if="index === breadcrumbs.length - 1">
-                                    <BreadcrumbPage>{{ item.title }}</BreadcrumbPage>
-                                </template>
-                                <template v-else>
-                                    <BreadcrumbLink :href="item.href">
-                                        {{ item.title }}
-                                    </BreadcrumbLink>
-                                </template>
-                            </BreadcrumbItemComponent>
-                            <BreadcrumbSeparator v-if="index !== breadcrumbs.length - 1" />
-                        </template>
-                    </BreadcrumbList>
-                </Breadcrumb>
+                <Breadcrumbs :breadcrumbs="breadcrumbs" />
             </div>
         </div>
     </div>

--- a/resources/js/components/AppSidebarHeader.vue
+++ b/resources/js/components/AppSidebarHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
+import Breadcrumbs from '@/components/Breadcrumbs.vue';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import type { BreadcrumbItemType } from '@/types';
 
@@ -15,23 +15,7 @@ defineProps<{
         <div class="flex items-center gap-2">
             <SidebarTrigger class="-ml-1" />
             <template v-if="breadcrumbs.length > 0">
-                <Breadcrumb>
-                    <BreadcrumbList>
-                        <template v-for="(item, index) in breadcrumbs" :key="index">
-                            <BreadcrumbItem>
-                                <template v-if="index === breadcrumbs.length - 1">
-                                    <BreadcrumbPage>{{ item.title }}</BreadcrumbPage>
-                                </template>
-                                <template v-else>
-                                    <BreadcrumbLink :href="item.href">
-                                        {{ item.title }}
-                                    </BreadcrumbLink>
-                                </template>
-                            </BreadcrumbItem>
-                            <BreadcrumbSeparator v-if="index !== breadcrumbs.length - 1" />
-                        </template>
-                    </BreadcrumbList>
-                </Breadcrumb>
+                <Breadcrumbs :breadcrumbs="breadcrumbs" />
             </template>
         </div>
     </header>

--- a/resources/js/components/Breadcrumbs.vue
+++ b/resources/js/components/Breadcrumbs.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+
+    import {
+        Breadcrumb,
+        BreadcrumbItem,
+        BreadcrumbLink,
+        BreadcrumbList,
+        BreadcrumbPage,
+        BreadcrumbSeparator
+    } from '@/components/ui/breadcrumb';
+
+    interface BreadcrumbItem {
+        title: string;
+        href?: string;
+    }
+
+    defineProps<{
+        breadcrumbs: BreadcrumbItem[];
+    }>();
+</script>
+
+<template>
+  <Breadcrumb>
+        <BreadcrumbList>
+            <template v-for="(item, index) in breadcrumbs" :key="index">
+                <BreadcrumbItem>
+                    <template v-if="index === breadcrumbs.length - 1">
+                        <BreadcrumbPage>{{ item.title }}</BreadcrumbPage>
+                    </template>
+                    <template v-else>
+                        <BreadcrumbLink :href="item.href">
+                            {{ item.title }}
+                        </BreadcrumbLink>
+                    </template>
+                </BreadcrumbItem>
+                <BreadcrumbSeparator v-if="index !== breadcrumbs.length - 1" />
+            </template>
+        </BreadcrumbList>
+    </Breadcrumb>
+</template>

--- a/resources/js/components/Breadcrumbs.vue
+++ b/resources/js/components/Breadcrumbs.vue
@@ -1,26 +1,18 @@
 <script setup lang="ts">
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 
-    import {
-        Breadcrumb,
-        BreadcrumbItem,
-        BreadcrumbLink,
-        BreadcrumbList,
-        BreadcrumbPage,
-        BreadcrumbSeparator
-    } from '@/components/ui/breadcrumb';
+interface BreadcrumbItem {
+    title: string;
+    href?: string;
+}
 
-    interface BreadcrumbItem {
-        title: string;
-        href?: string;
-    }
-
-    defineProps<{
-        breadcrumbs: BreadcrumbItem[];
-    }>();
+defineProps<{
+    breadcrumbs: BreadcrumbItem[];
+}>();
 </script>
 
 <template>
-  <Breadcrumb>
+    <Breadcrumb>
         <BreadcrumbList>
             <template v-for="(item, index) in breadcrumbs" :key="index">
                 <BreadcrumbItem>

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import AppLayout from '@/layouts/app/AppSidebarLayout.vue';
+import AppLayout from '@/layouts/app/AppHeaderLayout.vue';
 import type { BreadcrumbItemType } from '@/types';
 
 interface Props {

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import AppLayout from '@/layouts/app/AppHeaderLayout.vue';
+import AppLayout from '@/layouts/app/AppSidebarLayout.vue';
 import type { BreadcrumbItemType } from '@/types';
 
 interface Props {


### PR DESCRIPTION
This PR fix breadcrumb not displayed due to unknown breadcrumb component loaded in the `AppHeader.vue ` for the **Header Layout**.

### Step to Reproduce

Add 2 items in the breadcrumb items on the any page component.
Then it will display the breadcrumb