### PR TITLE
Fix: Vue type checking for `AvatarImage` component

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -165,7 +165,7 @@ const rightNavItems: NavItem[] = [
                                 class="relative size-10 w-auto rounded-full p-1 focus-within:ring-2 focus-within:ring-primary"
                             >
                                 <Avatar class="size-8 overflow-hidden rounded-full">
-                                    <AvatarImage :src="auth.user.avatar" :alt="auth.user.name" />
+                                    <AvatarImage v-if="auth.user.avatar" :src="auth.user.avatar" :alt="auth.user.name" />
                                     <AvatarFallback class="rounded-lg bg-neutral-200 font-semibold text-black dark:bg-neutral-700 dark:text-white">
                                         {{ getInitials(auth.user?.name) }}
                                     </AvatarFallback>


### PR DESCRIPTION
This PR fix browser console warning when `AvatarImage` component src prop was undefined. 
Uses Same as logic from `UserInfo` component but without using computed property

![2025-02-25_033024](https://github.com/user-attachments/assets/9b6f37f6-9d5a-4f1b-9715-04e37ae2c568)
