### PR TITLE
Update npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
                 "@headlessui/vue": "^1.7.23",
                 "@inertiajs/vue3": "^2.0.0-beta.3",
                 "@tailwindcss/forms": "^0.5.3",
-                "@types/node": "^22.10.2",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vueuse/core": "^12.0.0",
                 "autoprefixer": "^10.4.20",
@@ -25,11 +24,11 @@
                 "typescript": "^5.2.2",
                 "vite": "^6.0.3",
                 "vue": "^3.5.13",
-                "vue-tsc": "^2.2.0",
                 "ziggy-js": "^2.4.2"
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
+                "@types/node": "^22.13.5",
                 "@vue/eslint-config-typescript": "^14.3.0",
                 "eslint": "^9.17.0",
                 "eslint-config-prettier": "^10.0.1",
@@ -37,7 +36,8 @@
                 "prettier": "^3.4.2",
                 "prettier-plugin-organize-imports": "^4.1.0",
                 "prettier-plugin-tailwindcss": "^0.6.9",
-                "typescript-eslint": "^8.23.0"
+                "typescript-eslint": "^8.23.0",
+                "vue-tsc": "^2.2.4"
             },
             "optionalDependencies": {
                 "@rollup/rollup-linux-x64-gnu": "4.9.5",
@@ -1289,6 +1289,7 @@
             "version": "22.13.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
             "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -1516,6 +1517,7 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
             "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/source-map": "2.4.11"
@@ -1525,12 +1527,14 @@
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
             "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@volar/typescript": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
             "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "2.4.11",
@@ -1592,6 +1596,7 @@
             "version": "2.7.16",
             "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
             "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "de-indent": "^1.0.2",
@@ -1625,9 +1630,10 @@
             }
         },
         "node_modules/@vue/language-core": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.2.tgz",
-            "integrity": "sha512-QotO41kurE5PLf3vrNgGTk3QswO2PdUFjBwNiOi7zMmGhwb25PSTh9hD1MCgKC06AVv+8sZQvlL3Do4TTVHSiQ==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.4.tgz",
+            "integrity": "sha512-eGGdw7eWUwdIn9Fy/irJ7uavCGfgemuHQABgJ/hU1UgZFnbTg9VWeXvHQdhY+2SPQZWJqWXvRWIg67t4iWEa+Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/language-core": "~2.4.11",
@@ -1778,6 +1784,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.4.tgz",
             "integrity": "sha512-DJqqQD3XcsaQcQ1s+iE2jDUZmmQpXwHiR6fCAim/w87luaW+vmLY8fMlrdkmRwzaFXhkxf3rqPCR59tKVv1MDw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ansi-regex": {
@@ -2315,6 +2322,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
             "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -3160,6 +3168,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "he": "bin/he"
@@ -3581,6 +3590,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
             "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
@@ -3759,6 +3769,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-exists": {
@@ -4921,6 +4932,7 @@
             "version": "6.20.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/update-browserslist-db": {
@@ -5054,6 +5066,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
             "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/vue": {
@@ -5138,13 +5151,14 @@
             }
         },
         "node_modules/vue-tsc": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.2.tgz",
-            "integrity": "sha512-1icPKkxAA5KTAaSwg0wVWdE48EdsH8fgvcbAiqojP4jXKl6LEM3soiW1aG/zrWrFt8Mw1ncG2vG1PvpZpVfehA==",
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.4.tgz",
+            "integrity": "sha512-3EVHlxtpMXcb5bCaK7QDFTbEkMusDfVk0HVRrkv5hEb+Clpu9a96lKUXJAeD/akRlkoA4H8MCHgBDN19S6FnzA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@volar/typescript": "~2.4.11",
-                "@vue/language-core": "2.2.2"
+                "@vue/language-core": "2.2.4"
             },
             "bin": {
                 "vue-tsc": "bin/vue-tsc.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "vue-starter-kit",
+    "name": "laravel-vue-starter-kit",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -9,7 +9,6 @@
                 "@inertiajs/vue3": "^2.0.0-beta.3",
                 "@tailwindcss/forms": "^0.5.3",
                 "@types/node": "^22.10.2",
-                "@types/ziggy-js": "^1.3.3",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vueuse/core": "^12.0.0",
                 "autoprefixer": "^10.4.20",
@@ -1279,12 +1278,6 @@
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "license": "MIT"
         },
-        "node_modules/@types/history": {
-            "version": "4.7.11",
-            "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-            "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-            "license": "MIT"
-        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1312,15 +1305,6 @@
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
             "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
             "license": "MIT"
-        },
-        "node_modules/@types/ziggy-js": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/ziggy-js/-/ziggy-js-1.3.3.tgz",
-            "integrity": "sha512-vBsSiMYhpG6zMiFUFmGoeo/0Ff882m7GLmy2dutsnx9NI+bces+ap4e5tKrzy4TzAAFHlvU1Io6SN8IeUp689w==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/history": "^4.7.11"
-            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.24.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "@inertiajs/vue3": "^2.0.0-beta.3",
         "@tailwindcss/forms": "^0.5.3",
         "@types/node": "^22.10.2",
-        "@types/ziggy-js": "^1.3.3",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vueuse/core": "^12.0.0",
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@types/node": "^22.13.5",
         "@vue/eslint-config-typescript": "^14.3.0",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
@@ -18,13 +19,13 @@
         "prettier": "^3.4.2",
         "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.9",
-        "typescript-eslint": "^8.23.0"
+        "typescript-eslint": "^8.23.0",
+        "vue-tsc": "^2.2.4"
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.23",
         "@inertiajs/vue3": "^2.0.0-beta.3",
         "@tailwindcss/forms": "^0.5.3",
-        "@types/node": "^22.10.2",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vueuse/core": "^12.0.0",
         "autoprefixer": "^10.4.20",
@@ -41,7 +42,6 @@
         "typescript": "^5.2.2",
         "vite": "^6.0.3",
         "vue": "^3.5.13",
-        "vue-tsc": "^2.2.0",
         "ziggy-js": "^2.4.2"
     },
     "optionalDependencies": {


### PR DESCRIPTION
This PR removes a deprecated package and moves some packages to devDependencies.

Changes:

Removed:
- `@types/ziggy-js` (ziggy-js provides its own type definitions now)

Moved to devDependencies:
- `@types/node`
- `vue-tsc`