### PR TITLE
fix: add gap to DialogFooter in DeleteUser component

### DIFF
--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -70,7 +70,7 @@ const closeModal = () => {
                             <InputError :message="form.errors.password" />
                         </div>
 
-                        <DialogFooter>
+                        <DialogFooter class="gap-2">
                             <DialogClose as-child>
                                 <Button variant="secondary" @click="closeModal"> Cancel </Button>
                             </DialogClose>


### PR DESCRIPTION
This PR fixes the gap issue in the buttons of the DeleteUser component.

**Before:**

![vue-starter-kit](https://github.com/user-attachments/assets/5ccfb2ab-c429-478d-b982-0fe64ef786a7)


**After:**

![vue-starter-kit](https://github.com/user-attachments/assets/d8fe3350-563e-4d73-86ae-e9242df10988)
