### PR TITLE
Fix ShareData type

### DIFF
--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from 'lucide-vue-next';
+import type { PageProps } from '@inertiajs/core';
 
 export interface Auth {
     user: User;
@@ -16,7 +17,7 @@ export interface NavItem {
     isActive?: boolean;
 }
 
-export interface SharedData {
+export interface SharedData extends PageProps {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;


### PR DESCRIPTION
I notice this type issue:

<img width="820" alt="Screenshot 2025-02-25 at 09 20 44" src="https://github.com/user-attachments/assets/f0822cd0-6098-4c3b-be62-770f3910380a" />

I am not sure why `ShareData` doesn't satisfy `PageProps` since `PageProps` is of type ` { [k: string]: unknown } `. But with this PR it seems to be fixed.