### PR TITLE
Fix focus in delete-user modal

### DIFF
--- a/resources/js/components/ui/input/Input.vue
+++ b/resources/js/components/ui/input/Input.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
     class?: HTMLAttributes['class'];
 }>();
 
+const input = ref<HTMLInputElement | null>(null);
+
 const emits = defineEmits<{
     (e: 'update:modelValue', payload: string | number): void;
 }>();
@@ -17,10 +19,19 @@ const modelValue = useVModel(props, 'modelValue', emits, {
     passive: true,
     defaultValue: props.defaultValue,
 });
+
+function focus() {
+    input.value?.focus();
+}
+
+defineExpose({
+    focus,
+});
 </script>
 
 <template>
     <input
+        ref="input"
         v-model="modelValue"
         :class="
             cn(


### PR DESCRIPTION
This fix resolve next issue: `Unhandled Promise Rejection: TypeError: passwordInput.value?.focus is not a function. (In 'passwordInput.value?.focus()', 'passwordInput.value?.focus' is undefined)`