### PR TITLE
Refactor: use Inertia Link with fallback in Breadcrumbs component

### DIFF
--- a/resources/js/components/Breadcrumbs.vue
+++ b/resources/js/components/Breadcrumbs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
+import { Link } from '@inertiajs/vue3';
 
 interface BreadcrumbItem {
     title: string;
@@ -20,8 +21,8 @@ defineProps<{
                         <BreadcrumbPage>{{ item.title }}</BreadcrumbPage>
                     </template>
                     <template v-else>
-                        <BreadcrumbLink :href="item.href">
-                            {{ item.title }}
+                        <BreadcrumbLink>
+                            <Link :href="item.href ?? '#'">{{ item.title }}</Link>
                         </BreadcrumbLink>
                     </template>
                 </BreadcrumbItem>


### PR DESCRIPTION
Since the goal is to avoid a full-page reload for breadcrumbs and the type is optional, why not use a fallback route as well.