### PR TITLE
Remove SSR folder from source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
+/bootstrap/ssr

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpunit.cache
+/bootstrap/ssr
 /node_modules
 /public/build
 /public/hot
@@ -21,4 +22,3 @@ yarn-error.log
 /.nova
 /.vscode
 /.zed
-/bootstrap/ssr


### PR DESCRIPTION
Great work with these kits! One minor thing, looks like the `bootstrap/ssr` folder isn't being ignored by source control. Added that folder to the `.gitignore` file to fix that.

Same [change](https://github.com/laravel/react-starter-kit/pull/50) can be found in the React starter kit as well.