### PR TITLE
Card component accessibility with ARIA attributes

### DIFF
--- a/resources/js/components/ui/card/Card.vue
+++ b/resources/js/components/ui/card/Card.vue
@@ -4,11 +4,18 @@ import type { HTMLAttributes } from 'vue';
 
 const props = defineProps<{
     class?: HTMLAttributes['class'];
+    'aria-labelledby'?: string;
+    'aria-describedby'?: string;
 }>();
 </script>
 
 <template>
-    <div :class="cn('rounded-lg border bg-card text-card-foreground shadow-sm', props.class)">
+    <div 
+        :class="cn('rounded-lg border bg-card text-card-foreground shadow-sm', props.class)"
+        role="region"
+        :aria-labelledby="props['aria-labelledby']"
+        :aria-describedby="props['aria-describedby']"
+    >
         <slot />
     </div>
 </template>


### PR DESCRIPTION
feat(card): add ARIA attributes for accessibility

- Add role="region" to identify card as a distinct section
- Add aria-labelledby prop to associate with headings
- Add aria-describedby prop for descriptions

The Card component now supports screen readers better while maintaining its existing implementation pattern.