### PR TITLE
chore: reorder imports in resources/js/types/index.ts

### DIFF
--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -1,5 +1,5 @@
-import type { LucideIcon } from 'lucide-vue-next';
 import type { PageProps } from '@inertiajs/core';
+import type { LucideIcon } from 'lucide-vue-next';
 
 export interface Auth {
     user: User;


### PR DESCRIPTION
The import statements in the file resources/js/types/index.ts have been reordered.

The change was a result of running  `npm run format`