### PR TITLE
refactor: Update ZiggyVue import path to use 'ziggy-js'

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -4,7 +4,7 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import type { DefineComponent } from 'vue';
 import { createApp, h } from 'vue';
-import { ZiggyVue } from '../../vendor/tightenco/ziggy';
+import { ZiggyVue } from 'ziggy-js';
 import { initializeTheme } from './composables/useAppearance';
 
 // Extend ImportMeta interface for Vite...


### PR DESCRIPTION
The import path for ZiggyVue has been updated from

Before
```
import { ZiggyVue } from '../../vendor/tightenco/ziggy';
```
After
```
import { ZiggyVue } from 'ziggy-js';
```

This change aligns with the updated package structure and ensures compatibility with the latest version of the Ziggy library. No breaking changes are introduced as the functionality remains the same.