### PR TITLE
fix: reactive user updates in NavUser & fix password input focus in DeleteUser modal.

### DIFF
--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -31,7 +31,7 @@ const deleteUser = (e: Event) => {
     form.delete(route('profile.destroy'), {
         preserveScroll: true,
         onSuccess: () => closeModal(),
-        onError: () => passwordInput.value?.focus(),
+        onError: () => passwordInput.value?.$el.focus(),
         onFinish: () => form.reset(),
     });
 };

--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { nextTick } from 'vue';
 
 // Components
 import HeadingSmall from '@/components/HeadingSmall.vue';
@@ -19,8 +19,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-const passwordInput = ref<HTMLInputElement | null>(null);
-
 const form = useForm({
     password: '',
 });
@@ -31,7 +29,13 @@ const deleteUser = (e: Event) => {
     form.delete(route('profile.destroy'), {
         preserveScroll: true,
         onSuccess: () => closeModal(),
-        onError: () => passwordInput.value?.$el.focus(),
+        onError: () => {
+            nextTick(() => {
+                const formElement = e.target as HTMLFormElement;
+                const passwordInput = formElement.password as HTMLInputElement;
+                passwordInput.focus();
+            });
+        },
         onFinish: () => form.reset(),
     });
 };
@@ -66,7 +70,7 @@ const closeModal = () => {
 
                         <div class="grid gap-2">
                             <Label for="password" class="sr-only">Password</Label>
-                            <Input id="password" type="password" name="password" ref="passwordInput" v-model="form.password" placeholder="Password" />
+                            <Input id="password" type="password" name="password" v-model="form.password" placeholder="Password" />
                             <InputError :message="form.errors.password" />
                         </div>
 

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -6,9 +6,10 @@ import { type SharedData, type User } from '@/types';
 import { usePage } from '@inertiajs/vue3';
 import { ChevronsUpDown } from 'lucide-vue-next';
 import UserMenuContent from './UserMenuContent.vue';
+import { computed } from 'vue';
 
 const page = usePage<SharedData>();
-const user = page.props.auth.user as User;
+const user = computed(()=> page.props.auth.user as User);
 </script>
 
 <template>


### PR DESCRIPTION
**This PR ensures the user info in NavUser updates reactively after a profile update and properly focuses the password input on error in the DeleteUser modal, improving the overall user experience.**

### Fix 1: Ensure user avatar & username update immediately in NavUser.vue  after profile update.
- Changed `const user = page.props.auth.user as User;`  
  to `const user = computed(() => page.props.auth.user as User);`  
- This ensures the UI updates automatically after profile edits without requiring a page refresh.  

### Fix 2: Properly focus password input on error in DeleteUser modal  
- Fixed `TypeError: passwordInput.value?.focus is not a function`  
- Used `passwordInput.value?.$el?.focus()` instead of `passwordInput.value?.focus()`  
- This ensures correct access to the native `<input>` inside the `Input` component from shadcn-vue.