### PR TITLE
Remove unnecessary SQLite file creation in test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install Node Dependencies
         run: npm ci
 
-      - name: Create SQLite Database
-        run: touch database/database.sqlite
-
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 


### PR DESCRIPTION
First of all, thank you for providing amazing starter kits! 

In the test workflow (tests.yml), SQLite file creation is included.
However, since `phpunit.xml` configures SQLite to run **in memory** during test execution, SQLite file is not needed in the test CI.

https://github.com/laravel/vue-starter-kit/blob/41b7b6aca8cb2031f7f464e72226d4133340541e/phpunit.xml#L25-L26

I’ve also submitted same PRs for the React and Livewire starter kits:
React: https://github.com/laravel/react-starter-kit/pull/52
Livewire: https://github.com/laravel/livewire-starter-kit/pull/34