### PR TITLE
fix: double anchor tag in Breadcrumbs

### DIFF
--- a/resources/js/components/Breadcrumbs.vue
+++ b/resources/js/components/Breadcrumbs.vue
@@ -21,7 +21,7 @@ defineProps<{
                         <BreadcrumbPage>{{ item.title }}</BreadcrumbPage>
                     </template>
                     <template v-else>
-                        <BreadcrumbLink>
+                        <BreadcrumbLink as-child>
                             <Link :href="item.href ?? '#'">{{ item.title }}</Link>
                         </BreadcrumbLink>
                     </template>


### PR DESCRIPTION
Without `as-child`, this will render double nested `<a>` tags.