### PR TITLE
Wrong NavType prop

### DIFF
--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -12,7 +12,7 @@ export interface BreadcrumbItem {
 
 export interface NavItem {
     title: string;
-    href: string;
+    url: string;
     icon?: LucideIcon;
     isActive?: boolean;
 }


### PR DESCRIPTION
 AppSidebar.vue  `footerNavItems` sets `url` as the hyperlink, but it is defined as `href` in the NavItem props.

```
    {
        title: 'Github Repo',
        url: 'https://github.com/laravel/vue-starter-kit',
        icon: Folder,
    },
```