### PR TITLE
Ignore ziggy.js in Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 resources/js/components/ui/*
+resources/js/ziggy.js


### PR DESCRIPTION
The included GitHub test workflow runs `php artisan ziggy:generate` which creates the `resources/js/ziggy.js` file. This generated file would have its formatting changed when running Prettier with the included config.

This means that if the user adds a formatting check as part of their test workflow (e.g. `prettier --check`) it will fail.

As the file is auto-generated there should not be any issues ignoring it when manually running Prettier outside of the test workflow.