### PR TITLE
fix passwordInput HTMLInputElement error on onError focus

### DIFF
--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { useTemplateRef } from 'vue';
 
 // Components
 import HeadingSmall from '@/components/HeadingSmall.vue';
@@ -19,7 +19,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-const passwordInput = ref<HTMLInputElement | null>(null);
+const passwordInput = useTemplateRef<HTMLInputElement | null>(null);
 
 const form = useForm({
     password: '',


### PR DESCRIPTION
When deleting an account, if a wrong password is entered, an error is generated on the focus in onError