### PR TITLE
Fix Route Redirect for Settings Path

### DIFF
--- a/routes/settings.php
+++ b/routes/settings.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
 Route::middleware('auth')->group(function () {
-    Route::redirect('settings', 'settings/profile');
+    Route::redirect('settings', '/settings/profile');
 
     Route::get('settings/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('settings/profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
This PR updates the `Route::redirect` for the `settings` route to include a leading slash in the destination path. Previously, the redirect caused issues when accessing `/settings/` with a trailing slash, as Laravel would not properly resolve the relative path.

**Testing:**
- Visit `/settings` → should redirect correctly.
- Visit `/settings/` → should now also redirect correctly.
- Confirm that `/settings/profile` loads as expected.

