### PR TITLE
AppLogo class fixed

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -109,7 +109,7 @@ const rightNavItems: NavItem[] = [
                 </div>
 
                 <Link :href="route('dashboard')" class="flex items-center gap-x-2">
-                    <AppLogo class="hidden h-6 xl:block" />
+                    <AppLogo />
                 </Link>
 
                 <!-- Desktop Menu -->


### PR DESCRIPTION
The AppLogo component on the AppHeaderLayout, can not have a class because the component does not have a single root element.
<img width="425" alt="Screenshot 2025-03-03 at 21 46 55" src="https://github.com/user-attachments/assets/6fd30f8a-8eeb-4ff8-a89e-821507029fb0" />
