### PR TITLE
Add a `.prettierignore` rule to exclude `resources/views/mail/*` from formatting.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 resources/js/components/ui/*
 resources/js/ziggy.js
+resources/views/mail/*


### PR DESCRIPTION
This PR adds a new rule to `.prettierignore` to exclude `resources/views/mail/*` from automatic formatting. Email templates often contain embedded Blade syntax and inline styles, which Prettier's formatting rules can disrupt. Ignoring these files ensures that the email templates' intended structure and formatting remain intact.