### PR TITLE
Prevent exposing privileged info after logout

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -46,6 +46,8 @@ class AuthenticatedSessionController extends Controller
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
+        Inertia::clearHistory();
+
         return redirect('/');
     }
 }

--- a/config/inertia.php
+++ b/config/inertia.php
@@ -1,0 +1,73 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Server Side Rendering
+    |--------------------------------------------------------------------------
+    |
+    | These options configures if and how Inertia uses Server Side Rendering
+    | to pre-render the initial visits made to your application's pages.
+    |
+    | You can specify a custom SSR bundle path, or omit it to let Inertia
+    | try and automatically detect it for you.
+    |
+    | Do note that enabling these options will NOT automatically make SSR work,
+    | as a separate rendering service needs to be available. To learn more,
+    | please visit https://inertiajs.com/server-side-rendering
+    |
+    */
+
+    'ssr' => [
+
+        'enabled' => true,
+
+        'url' => 'http://127.0.0.1:13714',
+
+        // 'bundle' => base_path('bootstrap/ssr/ssr.mjs'),
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Testing
+    |--------------------------------------------------------------------------
+    |
+    | The values described here are used to locate Inertia components on the
+    | filesystem. For instance, when using `assertInertia`, the assertion
+    | attempts to locate the component as a file relative to any of the
+    | paths AND with any of the extensions specified here.
+    |
+    */
+
+    'testing' => [
+
+        'ensure_pages_exist' => true,
+
+        'page_paths' => [
+
+            resource_path('js/pages'),
+
+        ],
+
+        'page_extensions' => [
+
+            'js',
+            'jsx',
+            'svelte',
+            'ts',
+            'tsx',
+            'vue',
+
+        ],
+
+    ],
+
+    'history' => [
+
+        'encrypt' => true,
+
+    ],
+
+];


### PR DESCRIPTION
(Equivalent to https://github.com/laravel/react-starter-kit/pull/78)

After logout, auth-protected views are still accessible until page is refreshed.

Inertia docs warns about this behavior: https://inertiajs.com/history-encryption

## Steps to reproduce:

1. Login to dashboard page.
2. Logout.
3. Press back button in the browser.
4. Dashboard is shown again.

With this changes, it redirects to login when going back after logout.

Had to publish the full Inertia config file because it was not already present in the repository.