### PR TITLE
fix: input focus on delete/change password

### DIFF
--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { useTemplateRef } from 'vue';
 
 // Components
 import HeadingSmall from '@/components/HeadingSmall.vue';
@@ -19,7 +19,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-const passwordInput = ref<HTMLInputElement | null>(null);
+const passwordInput = useTemplateRef('passwordInput');
 
 const form = useForm({
     password: '',
@@ -31,7 +31,7 @@ const deleteUser = (e: Event) => {
     form.delete(route('profile.destroy'), {
         preserveScroll: true,
         onSuccess: () => closeModal(),
-        onError: () => passwordInput.value?.focus(),
+        onError: () => passwordInput.value?.$el.focus(),
         onFinish: () => form.reset(),
     });
 };

--- a/resources/js/pages/settings/Password.vue
+++ b/resources/js/pages/settings/Password.vue
@@ -3,7 +3,7 @@ import InputError from '@/components/InputError.vue';
 import AppLayout from '@/layouts/AppLayout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
 import { Head, useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { useTemplateRef } from 'vue';
 
 import HeadingSmall from '@/components/HeadingSmall.vue';
 import { Button } from '@/components/ui/button';
@@ -18,8 +18,8 @@ const breadcrumbItems: BreadcrumbItem[] = [
     },
 ];
 
-const passwordInput = ref<HTMLInputElement | null>(null);
-const currentPasswordInput = ref<HTMLInputElement | null>(null);
+const passwordInput = useTemplateRef('passwordInput');
+const currentPasswordInput = useTemplateRef('currentPasswordInput');
 
 const form = useForm({
     current_password: '',
@@ -34,15 +34,15 @@ const updatePassword = () => {
         onError: (errors: any) => {
             if (errors.password) {
                 form.reset('password', 'password_confirmation');
-                if (passwordInput.value instanceof HTMLInputElement) {
-                    passwordInput.value.focus();
+                if (passwordInput.value?.$el instanceof HTMLInputElement) {
+                    passwordInput.value.$el.focus();
                 }
             }
 
             if (errors.current_password) {
                 form.reset('current_password');
-                if (currentPasswordInput.value instanceof HTMLInputElement) {
-                    currentPasswordInput.value.focus();
+                if (currentPasswordInput.value?.$el instanceof HTMLInputElement) {
+                    currentPasswordInput.value.$el.focus();
                 }
             }
         },


### PR DESCRIPTION
<img width="733" alt="Screenshot 2025-04-10 at 00 13 52" src="https://github.com/user-attachments/assets/64d9c770-28f1-4948-a3de-6681731096a2" />

Previously, the input focus wasn't working correctly when:
1. Deleting a user
2. Changing a password

This commit also replaced user ref with Vue 3.5+'s [useTemplateRef](https://vuejs.org/guide/essentials/template-refs)

