### PR TITLE
Fix `tabindex` focus issue on Login Page

### DIFF
--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -71,9 +71,9 @@ const submit = () => {
                     <InputError :message="form.errors.password" />
                 </div>
 
-                <div class="flex items-center justify-between" :tabindex="3">
+                <div class="flex items-center justify-between">
                     <Label for="remember" class="flex items-center space-x-3">
-                        <Checkbox id="remember" v-model="form.remember" :tabindex="4" />
+                        <Checkbox id="remember" v-model="form.remember" :tabindex="3" />
                         <span>Remember me</span>
                     </Label>
                 </div>


### PR DESCRIPTION
This PR fixes an issue with a `tabindex` attribute being on the `<div>` element around the "Remember me" checkbox, which provides no functionality when being tab-focused (and trying to enter/space to toggle).

The React starter kit doesn't have this issue.
With this fix, the tab focus behaviour matches the one of the React starter kit on the Login Form.

Before:
<img width="490" alt="Screenshot 2025-04-11 at 15 45 04" src="https://github.com/user-attachments/assets/229aa36b-6277-4856-bcdb-ea7709ac09af" />


After (one less tab-press):
<img width="469" alt="Screenshot 2025-04-11 at 15 38 31" src="https://github.com/user-attachments/assets/f2f4ed37-8e1b-4d51-aadf-545d8160f768" />
