### PR TITLE
Sidebar state fix

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -50,7 +50,7 @@ class HandleInertiaRequests extends Middleware
                 ...(new Ziggy)->toArray(),
                 'location' => $request->url(),
             ],
-            'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'sidebarOpen' => ! $request->hasCookie('sidebar:state') || $request->cookie('sidebar:state') === 'true',
         ];
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,7 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
+        $middleware->encryptCookies(except: ['appearance', 'sidebar:state']);
 
         $middleware->web(append: [
             HandleAppearance::class,


### PR DESCRIPTION
In shadcn-vue docs they mention that SIDEBAR_COOKIE_NAME is `sidebar_state` but in the actual code in [sidebar/utils.ts](https://github.com/unovue/shadcn-vue/blob/e5fbf5f5553b8e58a32625291540b94c8fc8cb87/apps/www/src/registry/default/ui/sidebar/utils.ts#L4) it's `sidebar:state` (with semicolon)

Without this fix, the sidebar looses its state everytime the user navigates to a different page or refreshes the page.