### PR TITLE
Adding the intertia config to use lowercase pages

### DIFF
--- a/config/inertia.php
+++ b/config/inertia.php
@@ -47,11 +47,6 @@ return [
             'tsx',
             'vue',
         ],
-
-    ],
-
-    'history' => [
-        'encrypt' => false,
     ],
 
 ];


### PR DESCRIPTION
When developers run Inertia tests on machines like Linux, inertia by default looks in `resources/js/Pages` directory instead of `resources/js/pages`.

This PR will fix that.