### PR TITLE
Email verification should work across devices

### DIFF
--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -3,26 +3,39 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
 
 class VerifyEmailController extends Controller
 {
     /**
      * Mark the authenticated user's email address as verified.
      */
-    public function __invoke(EmailVerificationRequest $request): RedirectResponse
+    public function __invoke(Request $request, int $id, string $hash): RedirectResponse
     {
-        if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        if (! $request->hasValidSignature()) {
+            abort(403, 'Invalid or expired verification link.');
         }
-
-        if ($request->user()->markEmailAsVerified()) {
-            /** @var \Illuminate\Contracts\Auth\MustVerifyEmail $user */
-            $user = $request->user();
+    
+        $user = User::findOrFail($id);
+    
+        if (! hash_equals($hash, sha1($user->getEmailForVerification()))) {
+            abort(403, 'Invalid verification hash.');
+        }
+    
+        // Now you can verify the email
+        if (! $user->hasVerifiedEmail()) {
+            $user->markEmailAsVerified();
+            
+            // Fire event when email is verified
             event(new Verified($user));
         }
+        
+        // Always log the user in, regardless of verification status
+        Auth::login($user);
 
         return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
     }


### PR DESCRIPTION
The current Verify Email functionality utilizes the EmailVerificationRequest here: https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php, which fails when a user clicks the verification email from a different device or browser.

This update removes the need for the user to be logged in when verifying their email. Instead, we check the id and hash directly from the signed URL. We use hasValidSignature() to make sure the link hasn’t been tampered with or expired, and then compare the hash to a SHA-1 version of the user’s email to confirm it’s legit.

With this update, the email verification flow is still secure and has a better user experience.

@taylorotwell, let me know if this looks good. I have PR's for this in the other starter kits but wanted to get your thoughts. Should I instead update the EmailVerificationRequest from inside the Laravel framework to work this way (https://github.com/laravel/framework/blob/12.x/src/Illuminate/Foundation/Auth/EmailVerificationRequest.php), or is it fine to add it in each starter kit?

Let me know 👍 Thanks!
