### PR TITLE
Reopen: Fix user reactivity in Navbar and improve password focus handling (prev. PR #54)

### DIFF
--- a/resources/js/components/DeleteUser.vue
+++ b/resources/js/components/DeleteUser.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useForm } from '@inertiajs/vue3';
-import { ref } from 'vue';
+import { nextTick } from 'vue';
 
 // Components
 import HeadingSmall from '@/components/HeadingSmall.vue';
@@ -19,8 +19,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-const passwordInput = ref<HTMLInputElement | null>(null);
-
 const form = useForm({
     password: '',
 });
@@ -31,7 +29,13 @@ const deleteUser = (e: Event) => {
     form.delete(route('profile.destroy'), {
         preserveScroll: true,
         onSuccess: () => closeModal(),
-        onError: () => passwordInput.value?.focus(),
+        onError: () => {
+            nextTick(() => {
+                const formElement = e.target as HTMLFormElement;
+                const passwordInput = formElement.password as HTMLInputElement;
+                passwordInput.focus();
+            });
+        },
         onFinish: () => form.reset(),
     });
 };
@@ -66,7 +70,7 @@ const closeModal = () => {
 
                         <div class="grid gap-2">
                             <Label for="password" class="sr-only">Password</Label>
-                            <Input id="password" type="password" name="password" ref="passwordInput" v-model="form.password" placeholder="Password" />
+                            <Input id="password" type="password" name="password" v-model="form.password" placeholder="Password" />
                             <InputError :message="form.errors.password" />
                         </div>
 

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -5,10 +5,11 @@ import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/c
 import { type User } from '@/types';
 import { usePage } from '@inertiajs/vue3';
 import { ChevronsUpDown } from 'lucide-vue-next';
+import { computed } from 'vue';
 import UserMenuContent from './UserMenuContent.vue';
 
 const page = usePage();
-const user = page.props.auth.user as User;
+const user = computed(() => page.props.auth.user as User);
 const { isMobile, state } = useSidebar();
 </script>
 
@@ -18,7 +19,7 @@ const { isMobile, state } = useSidebar();
             <DropdownMenu>
                 <DropdownMenuTrigger as-child>
                     <SidebarMenuButton size="lg" class="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground">
-                        <UserInfo :user="user" />
+                        <UserInfo :user />
                         <ChevronsUpDown class="ml-auto size-4" />
                     </SidebarMenuButton>
                 </DropdownMenuTrigger>
@@ -28,7 +29,7 @@ const { isMobile, state } = useSidebar();
                     align="end"
                     :side-offset="4"
                 >
-                    <UserMenuContent :user="user" />
+                    <UserMenuContent :user />
                 </DropdownMenuContent>
             </DropdownMenu>
         </SidebarMenuItem>


### PR DESCRIPTION
This PR is a refreshed version of my previous contribution [#54](https://github.com/laravel/vue-starter-kit/pull/54), which was closed due to my unavailability and unresolved merge conflicts. I’ve now resolved all conflicts, refined the changes, and ensured full compatibility with the latest codebase.

---

### ✅ What's Updated

#### 🔁 **Refactor: Make `user` reactive using `computed` and simplify prop passing**

- Converted `user` from a static variable to a `computed` property for better reactivity.
- Fixes the issue where updated user data (e.g. after profile edits) wasn't reflected in the Navbar unless the page was refreshed.
- Updated prop binding syntax from `:user="user"` to shorthand `:user` for cleaner template usage.

#### 🛠️ **Fix: Properly focus password input on error in Delete User modal**

- Removed `passwordInput` ref and reliance on `$el` to access native `<input>` inside the `Input` component.
- Fixed `TypeError: passwordInput.value?.focus is not a function` caused by trying to focus the component instance instead of the actual input.
- Replaced it with native DOM access using `formElement.password` inside the `onError` callback.
- Used `nextTick()` to ensure DOM is updated before calling `.focus()`.

---

### 💡 Why it matters

These changes enhance both UX and code maintainability:

- The Navbar now dynamically reflects authenticated user changes without reloads.
- The Delete User modal now reliably focuses the password field on validation error — even when using shadcn-vue components.


---

### 🎥 Visual Demos (Before → After)

Here’s a visual comparison of the previous behavior vs. the updated experience:

#### 🔁 Navbar user data updates automatically after profile changes (no page refresh needed)

![Navbar](https://github.com/user-attachments/assets/0d2a1de9-edbe-49ce-b22c-b18db638cf80)

#### 🛠️ Password input now correctly focuses on error

![Password Modal](https://github.com/user-attachments/assets/da28877e-6135-48e8-8df0-ba9f131742df)

---

### 📎 Related

- Original PR: [[#54](https://github.com/laravel/vue-starter-kit/pull/54)](https://github.com/laravel/vue-starter-kit/pull/54)