### PR TITLE
Fix various TypeScript issues, simplify ziggy-js integration and shared props usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
-                "@inertiajs/vue3": "^2.0.0-beta.3",
+                "@inertiajs/vue3": "^2.0.0",
                 "@tailwindcss/vite": "^4.1.1",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vueuse/core": "^12.8.2",
@@ -13,7 +13,6 @@
                 "clsx": "^2.1.1",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^1.0",
-                "lucide": "^0.468.0",
                 "lucide-vue-next": "^0.468.0",
                 "reka-ui": "^2.2.0",
                 "tailwind-merge": "^3.2.0",
@@ -3484,12 +3483,6 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lucide": {
-            "version": "0.468.0",
-            "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.468.0.tgz",
-            "integrity": "sha512-UFbgwji/ZnAV7iTTE4jujyTV7J95AILKyATDUrqOJrMcUGfXvGjw3c1mcuHZUX2oJfkrAGU9KoxkrLQk2jjtiA==",
-            "license": "ISC"
         },
         "node_modules/lucide-vue-next": {
             "version": "0.468.0",

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -7,19 +7,6 @@ import { createApp, h } from 'vue';
 import { ZiggyVue } from 'ziggy-js';
 import { initializeTheme } from './composables/useAppearance';
 
-// Extend ImportMeta interface for Vite...
-declare module 'vite/client' {
-    interface ImportMetaEnv {
-        readonly VITE_APP_NAME: string;
-        [key: string]: string | boolean | undefined;
-    }
-
-    interface ImportMeta {
-        readonly env: ImportMetaEnv;
-        readonly glob: <T>(pattern: string) => Record<string, () => Promise<T>>;
-    }
-}
-
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 createInertiaApp({

--- a/resources/js/components/AppShell.vue
+++ b/resources/js/components/AppShell.vue
@@ -1,15 +1,13 @@
 <script setup lang="ts">
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { usePage } from '@inertiajs/vue3';
-import { SharedData } from '@/types';
-
 interface Props {
     variant?: 'header' | 'sidebar';
 }
 
 defineProps<Props>();
 
-const isOpen = usePage<SharedData>().props.sidebarOpen;
+const isOpen = usePage().props.sidebarOpen;
 </script>
 
 <template>

--- a/resources/js/components/NavMain.vue
+++ b/resources/js/components/NavMain.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
-import { type NavItem, type SharedData } from '@/types';
+import { type NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
 
 defineProps<{
     items: NavItem[];
 }>();
 
-const page = usePage<SharedData>();
+const page = usePage();
 </script>
 
 <template>
@@ -15,7 +15,7 @@ const page = usePage<SharedData>();
         <SidebarGroupLabel>Platform</SidebarGroupLabel>
         <SidebarMenu>
             <SidebarMenuItem v-for="item in items" :key="item.title">
-                <SidebarMenuButton 
+                <SidebarMenuButton
                     as-child :is-active="item.href === page.url"
                     :tooltip="item.title"
                 >

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -2,12 +2,12 @@
 import UserInfo from '@/components/UserInfo.vue';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem, useSidebar } from '@/components/ui/sidebar';
-import { type SharedData, type User } from '@/types';
+import { type User } from '@/types';
 import { usePage } from '@inertiajs/vue3';
 import { ChevronsUpDown } from 'lucide-vue-next';
 import UserMenuContent from './UserMenuContent.vue';
 
-const page = usePage<SharedData>();
+const page = usePage();
 const user = page.props.auth.user as User;
 const { isMobile, state } = useSidebar();
 </script>
@@ -22,10 +22,10 @@ const { isMobile, state } = useSidebar();
                         <ChevronsUpDown class="ml-auto size-4" />
                     </SidebarMenuButton>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent 
+                <DropdownMenuContent
                     class="w-(--reka-dropdown-menu-trigger-width) min-w-56 rounded-lg"
                     :side="isMobile ? 'bottom' : state === 'collapsed' ? 'left' : 'bottom'"
-                    align="end" 
+                    align="end"
                     :side-offset="4"
                 >
                     <UserMenuContent :user="user" />

--- a/resources/js/components/UserInfo.vue
+++ b/resources/js/components/UserInfo.vue
@@ -21,7 +21,7 @@ const showAvatar = computed(() => props.user.avatar && props.user.avatar !== '')
 
 <template>
     <Avatar class="h-8 w-8 overflow-hidden rounded-lg">
-        <AvatarImage v-if="showAvatar" :src="user.avatar" :alt="user.name" />
+        <AvatarImage v-if="showAvatar" :src="user.avatar!" :alt="user.name" />
         <AvatarFallback class="rounded-lg text-black dark:text-white">
             {{ getInitials(user.name) }}
         </AvatarFallback>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -215,7 +215,7 @@ import { Head, Link } from '@inertiajs/vue3';
                             />
                         </g>
                         <g
-                            :style="{ mixBlendMode: 'plus-darker' }"
+                            :style="`mixBlendMode: 'plus-darker'`"
                             class="duration-750 starting:translate-y-4 starting:opacity-0 translate-y-0 opacity-100 transition-all delay-300"
                         >
                             <path

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -9,7 +9,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
 import SettingsLayout from '@/layouts/settings/Layout.vue';
-import { type BreadcrumbItem, type SharedData, type User } from '@/types';
+import { type BreadcrumbItem, type User } from '@/types';
 
 interface Props {
     mustVerifyEmail: boolean;
@@ -25,7 +25,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-const page = usePage<SharedData>();
+const page = usePage();
 const user = page.props.auth.user as User;
 
 const form = useForm({

--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -2,7 +2,7 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { renderToString } from '@vue/server-renderer';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createApp, DefineComponent, h } from 'vue';
+import { createSSRApp, DefineComponent, h } from 'vue';
 import { ZiggyVue } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
@@ -14,13 +14,14 @@ createServer((page) =>
         title: (title) => `${title} - ${appName}`,
         resolve: resolvePage,
         setup: ({ App, props, plugin }) =>
-            createApp({ render: () => h(App, props) })
+            createSSRApp({ render: () => h(App, props) })
                 .use(plugin)
                 .use(ZiggyVue, {
                     ...page.props.ziggy,
                     location: new URL(page.props.ziggy.location),
                 }),
     }),
+    { cluster: true },
 );
 
 function resolvePage(name: string) {

--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -2,8 +2,8 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { renderToString } from '@vue/server-renderer';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createSSRApp, DefineComponent, h } from 'vue';
-import { route as ziggyRoute } from 'ziggy-js';
+import { createApp, DefineComponent, h } from 'vue';
+import { ZiggyVue } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -13,30 +13,13 @@ createServer((page) =>
         render: renderToString,
         title: (title) => `${title} - ${appName}`,
         resolve: resolvePage,
-        setup({ App, props, plugin }) {
-            const app = createSSRApp({ render: () => h(App, props) });
-
-            // Configure Ziggy for SSR...
-            const ziggyConfig = {
-                ...page.props.ziggy,
-                location: new URL(page.props.ziggy.location),
-            };
-
-            // Create route function...
-            const route = (name: string, params?: any, absolute?: boolean) => ziggyRoute(name, params, absolute, ziggyConfig);
-
-            // Make route function available globally...
-            app.config.globalProperties.route = route;
-
-            // Make route function available globally for SSR...
-            if (typeof window === 'undefined') {
-                global.route = route;
-            }
-
-            app.use(plugin);
-
-            return app;
-        },
+        setup: ({ App, props, plugin }) =>
+            createApp({ render: () => h(App, props) })
+                .use(plugin)
+                .use(ZiggyVue, {
+                    ...page.props.ziggy,
+                    location: new URL(page.props.ziggy.location),
+                }),
     }),
 );
 

--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -2,7 +2,7 @@ import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
 import { renderToString } from '@vue/server-renderer';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
-import { createSSRApp, h } from 'vue';
+import { createSSRApp, DefineComponent, h } from 'vue';
 import { route as ziggyRoute } from 'ziggy-js';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
@@ -12,7 +12,7 @@ createServer((page) =>
         page,
         render: renderToString,
         title: (title) => `${title} - ${appName}`,
-        resolve: (name) => resolvePageComponent(`./pages/${name}.vue`, import.meta.glob('./pages/**/*.vue')),
+        resolve: resolvePage,
         setup({ App, props, plugin }) {
             const app = createSSRApp({ render: () => h(App, props) });
 
@@ -39,3 +39,9 @@ createServer((page) =>
         },
     }),
 );
+
+function resolvePage(name: string) {
+    const pages = import.meta.glob<DefineComponent>('./pages/**/*.vue');
+
+    return resolvePageComponent<DefineComponent>(`./pages/${name}.vue`, pages);
+}

--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -3,3 +3,16 @@ import type { route as routeFn } from 'ziggy-js';
 declare global {
     const route: typeof routeFn;
 }
+
+// Extend ImportMeta interface for Vite...
+declare module 'vite/client' {
+    interface ImportMetaEnv {
+        readonly VITE_APP_NAME: string;
+        [key: string]: string | boolean | undefined;
+    }
+
+    interface ImportMeta {
+        readonly env: ImportMetaEnv;
+        readonly glob: <T>(pattern: string) => Record<string, () => Promise<T>>;
+    }
+}

--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -22,6 +22,5 @@ declare module '@vue/runtime-core' {
         $inertia: typeof Router;
         $page: Page;
         $headManager: ReturnType<typeof createHeadManager>;
-        route: AppRouter;
     }
 }

--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -16,3 +16,12 @@ declare module 'vite/client' {
 declare module '@inertiajs/core' {
     interface PageProps extends InertiaPageProps, AppPageProps {}
 }
+
+declare module '@vue/runtime-core' {
+    interface ComponentCustomProperties {
+        $inertia: typeof Router;
+        $page: Page;
+        $headManager: ReturnType<typeof createHeadManager>;
+        route: AppRouter;
+    }
+}

--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -1,8 +1,4 @@
-import type { route as routeFn } from 'ziggy-js';
-
-declare global {
-    const route: typeof routeFn;
-}
+import { AppPageProps } from '@/types/index';
 
 // Extend ImportMeta interface for Vite...
 declare module 'vite/client' {
@@ -15,4 +11,8 @@ declare module 'vite/client' {
         readonly env: ImportMetaEnv;
         readonly glob: <T>(pattern: string) => Record<string, () => Promise<T>>;
     }
+}
+
+declare module '@inertiajs/core' {
+    interface PageProps extends InertiaPageProps, AppPageProps {}
 }

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -1,4 +1,3 @@
-import type { PageProps } from '@inertiajs/core';
 import type { LucideIcon } from 'lucide-vue-next';
 import type { Config } from 'ziggy-js';
 
@@ -18,13 +17,13 @@ export interface NavItem {
     isActive?: boolean;
 }
 
-export interface SharedData extends PageProps {
+export type AppPageProps<T extends Record<string, unknown> = Record<string, unknown>> = T & {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
     ziggy: Config & { location: string };
     sidebarOpen: boolean;
-}
+};
 
 export interface User {
     id: number;

--- a/resources/js/types/ziggy.d.ts
+++ b/resources/js/types/ziggy.d.ts
@@ -1,8 +1,7 @@
-import { RouteParams, Router } from 'ziggy-js';
+import { route } from 'ziggy-js';
 
 declare global {
-    function route(): Router;
-    function route(name: string, params?: RouteParams<typeof name> | undefined, absolute?: boolean): string;
+    let route: typeof route;
 }
 
 declare module '@vue/runtime-core' {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,6 @@
         // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
         "paths": {
             /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/*"],
-            "ziggy-js": ["./vendor/tightenco/ziggy"]
         },
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,7 +40,6 @@
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
         "types": [
             "vite/client",
-            "vue/tsx",
             "./resources/js/types"
         ] /* Specify type package names to be included without being referenced in a source file. */,
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,7 @@
 import vue from '@vitejs/plugin-vue';
 import laravel from 'laravel-vite-plugin';
 import path from 'path';
-import tailwindcss from "@tailwindcss/vite";
-import { resolve } from 'node:path';
+import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -25,7 +24,6 @@ export default defineConfig({
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './resources/js'),
-            'ziggy-js': resolve(__dirname, 'vendor/tightenco/ziggy'),
         },
     },
 });


### PR DESCRIPTION
This pull request simplifies type usage, removes unused imports, and improves the SSR setup.

### Ziggy-JS

While following the Ziggy-JS setup guide, I noticed that our ssr.ts file does a lot of unnecessary work. We can replace most of it with the ziggyVue plugin. We also don’t need the Ziggy alias pointing to the vendor directory, since Ziggy is already installed as a JS dependency. Finally, I added proper Vue-specific route definitions.

### TypeScript Types

- SharedProps: Refactored to extend and override the package’s App props, so we can use the usePage helper without manually declaring prop types each time.
- Inertia helpers: Added missing type definitions for Inertia helper functions used in template files.
- tsconfig.json: Removed the non-existent `vue/tsx` entry from the types array. It wasn’t provided by any installed package and caused errors during vue-tsc type checks.