### PR TITLE
remove lucide lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "vue-tsc": "^2.2.4"
     },
     "dependencies": {
-        "@inertiajs/vue3": "^2.0.0-beta.3",
+        "@inertiajs/vue3": "^2.0.0",
         "@tailwindcss/vite": "^4.1.1",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vueuse/core": "^12.8.2",
@@ -31,7 +31,6 @@
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.0",
-        "lucide": "^0.468.0",
         "lucide-vue-next": "^0.468.0",
         "reka-ui": "^2.2.0",
         "tailwind-merge": "^3.2.0",


### PR DESCRIPTION
This removes `lucide` lib, since `lucide-vue-next` is the oficial way to use lucide in vue and it is already installed https://lucide.dev/guide/packages/lucide-vue-next