### PR TITLE
Move appearance ref definition outside useAppearance()

### DIFF
--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -62,9 +62,9 @@ export function initializeTheme() {
     mediaQuery()?.addEventListener('change', handleSystemThemeChange);
 }
 
-export function useAppearance() {
-    const appearance = ref<Appearance>('system');
+const appearance = ref<Appearance>('system');
 
+export function useAppearance() {
     onMounted(() => {
         const savedAppearance = localStorage.getItem('appearance') as Appearance | null;
 


### PR DESCRIPTION
The appearance ref is currently scoped within the useAppearance composable. Meaning that whenever you import the useAppearance composable a new appearance ref instance will be created. When you need the appearance in multiple places in your app you'll end up with different appearance instances, while its useful if the appearance instance would be the same/stay in sync between all components where it's used.

Moving the appearance definition outside useAppearance resolves this, resulting in the same appearance instance being returned when importing it like:
```
import { useAppearance } from "@/Composables/useAppearance";

const { appearance } = useAppearance();
```