### PR TITLE
Document TypeScript issues in app.ts and tsconfig.json (VS Code warnings)

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -7,6 +7,10 @@ import { createApp, h } from 'vue';
 import { ZiggyVue } from 'ziggy-js';
 import { initializeTheme } from './composables/useAppearance';
 
+// VS Code warning: "File 'vite/client.d.ts' is not a module" (TS2306)
+// This import is still safe to use for type support in Vite projects.
+// See related Vite issue: https://github.com/vitejs/vite/issues/5370
+
 // Extend ImportMeta interface for Vite...
 declare module 'vite/client' {
     interface ImportMetaEnv {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,11 +39,14 @@
         },
         // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
         // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+
+        // "types": ["vue/tsx"]  // Causes warning if '@vue/tsx-jsx' is not installed, which it appears is not installed by default
         "types": [
             "vite/client",
             "vue/tsx",
             "./resources/js/types"
         ] /* Specify type package names to be included without being referenced in a source file. */,
+
         // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
         // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
         // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */


### PR DESCRIPTION
This PR documents two VS Code TypeScript warnings encountered when using the starter kit:

1. **TS2306 in app.ts**
   - `"File 'vite/client.d.ts' is not a module."`
   - This comes from `import 'vite/client';` and can be safely ignored.
   - A comment has been added to explain the warning and link to the relevant Vite issue.

2. **Missing type definition 'vue/tsx' in tsconfig.json**
   - `"Cannot find type definition file for 'vue/tsx'"`
   - This likely comes from the line `"types": ["vue/tsx"]` without the `@vue/tsx-jsx` package being installed.
   - A comment has been added suggesting removal or further clarification.

These TypeScript warnings may be confusing to new users of the vue-starter-kit.
The additions are mostly intended to bring this to the attention of the developers of the vue-starter-kit and could also help new users who may be confused by the warnings.