### PR TITLE
ui: fix AppHeader menu item

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -117,13 +117,12 @@ const rightNavItems: NavItem[] = [
                     <NavigationMenu class="ml-10 flex h-full items-stretch">
                         <NavigationMenuList class="flex h-full items-stretch space-x-2">
                             <NavigationMenuItem v-for="(item, index) in mainNavItems" :key="index" class="relative flex h-full items-center">
-                                <Link :href="item.href">
-                                    <NavigationMenuLink
-                                        :class="[navigationMenuTriggerStyle(), activeItemStyles(item.href), 'h-9 cursor-pointer px-3']"
-                                    >
-                                        <component v-if="item.icon" :is="item.icon" class="mr-2 h-4 w-4" />
-                                        {{ item.title }}
-                                    </NavigationMenuLink>
+                                <Link
+                                    :class="[navigationMenuTriggerStyle(), activeItemStyles(item.href), 'h-9 cursor-pointer px-3']"
+                                    :href="item.href"
+                                >
+                                    <component v-if="item.icon" :is="item.icon" class="mr-2 h-4 w-4" />
+                                    {{ item.title }}
                                 </Link>
                                 <div
                                     v-if="isCurrentRoute(item.href)"

--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -8,7 +8,6 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/compon
 import {
     NavigationMenu,
     NavigationMenuItem,
-    NavigationMenuLink,
     NavigationMenuList,
     navigationMenuTriggerStyle,
 } from '@/components/ui/navigation-menu';


### PR DESCRIPTION
Like [react-starter-kit](https://github.com/laravel/react-starter-kit/blob/a112a23e1a54c59a91036b781ce686ec54e35262/resources/js/components/app-header.tsx#L107), don't use NavigationMenuLink inside Link

Before:
![Capture d’écran 2025-05-07 à 13 50 13](https://github.com/user-attachments/assets/aedd41aa-75de-4a38-bef3-dc0ec35a6805)

After:
![Capture d’écran 2025-05-07 à 13 52 15](https://github.com/user-attachments/assets/4a9919a6-22ed-4aa9-a65f-3d8ba488b5b7)
