### PR TITLE
Fix layout margin issue when sidebar is collapsed, after override by recent update

### DIFF
--- a/resources/js/components/ui/sidebar/SidebarInset.vue
+++ b/resources/js/components/ui/sidebar/SidebarInset.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
     data-slot="sidebar-inset"
     :class="cn(
       'bg-background relative flex w-full flex-1 flex-col',
-      'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+      'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0',
       props.class,
     )"
   >


### PR DESCRIPTION
The margin adjustment for the layout when the sidebar is collapsed was unintentionally overridden by a recent update. This commit restores the previous fix by @tnylea  to ensure the sidebar looks symmetrical when it's collapsed.

See Similar PR: https://github.com/laravel/react-starter-kit/pull/64