### PR TITLE
Remove redundant `@layer base` from app.css

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -164,20 +164,6 @@
 }
 
 @layer base {
-    * {
-        @apply border-border;
-    }
-
-    body {
-        @apply bg-background text-foreground;
-    }
-}
-
-/*
-  ---break---
-*/
-
-@layer base {
   * {
     @apply border-border outline-ring/50;
   }


### PR DESCRIPTION
I feel this is redundant code that was left by accident when adding `outline-ring/50` to the base layer?
Originally added by @tnylea in PR #93, maybe you can shine some light on it if it was deliberate. 