### PR TITLE
fix: handle conflicting variable with same name

### DIFF
--- a/resources/js/components/Breadcrumbs.vue
+++ b/resources/js/components/Breadcrumbs.vue
@@ -2,13 +2,13 @@
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
 import { Link } from '@inertiajs/vue3';
 
-interface BreadcrumbItem {
+interface BreadcrumbItemType {
     title: string;
     href?: string;
 }
 
 defineProps<{
-    breadcrumbs: BreadcrumbItem[];
+    breadcrumbs: BreadcrumbItemType[];
 }>();
 </script>
 


### PR DESCRIPTION
The name BreadcrumbItem it's conflicting with component and type.