### PR TITLE
Fix: Str::lower() expects string, Stringable given

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -80,6 +80,6 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+        return Str::transliterate(Str::lower($this->string('email')->value()).'|'.$this->ip());
     }
 }


### PR DESCRIPTION
At the start of every project, phpstan complains that $this->string('email') is not a string but a Illuminate\Support\Stringable. 
This PR fixes that issue.