### PR TITLE
Fix overflow-x on AppContent

### DIFF
--- a/resources/js/layouts/app/AppSidebarLayout.vue
+++ b/resources/js/layouts/app/AppSidebarLayout.vue
@@ -17,7 +17,7 @@ withDefaults(defineProps<Props>(), {
 <template>
     <AppShell variant="sidebar">
         <AppSidebar />
-        <AppContent variant="sidebar">
+        <AppContent variant="sidebar" class="overflow-x-hidden">
             <AppSidebarHeader :breadcrumbs="breadcrumbs" />
             <slot />
         </AppContent>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -16,7 +16,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     <Head title="Dashboard" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 overflow-x-auto">
             <div class="grid auto-rows-min gap-4 md:grid-cols-3">
                 <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
                     <PlaceholderPattern />


### PR DESCRIPTION
### Copy from PR

Please take a look at https://github.com/laravel/react-starter-kit/pull/88. It's the same change, but for Vue.

### Reason for the PR
In every new project, I make a small but essential change: I set `overflow-x-hidden` on `AppContent`.

### Why?
Components like `shadcn/table` can cause unexpected horizontal scrolling on Dashboard.vue. To ensure a smoother experience, I want only the AppContent to be scrollable—without affecting the entire layout.

### Before (Desktop)

https://github.com/user-attachments/assets/742fbef5-e7a0-4179-9dd2-e21d0452bfa8

### After (Desktop)

https://github.com/user-attachments/assets/dbbb989a-aa56-4165-b643-e71da03d7841

### Before (Mobile)

https://github.com/user-attachments/assets/28efd8c1-134c-44d9-bd10-7c0655c5829e

### After (Mobile)

https://github.com/user-attachments/assets/548a64db-bea9-4126-bc11-577f23bd587e