### PR TITLE
chore: make consistent breadcrumbItems variable name

### DIFF
--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -18,7 +18,7 @@ interface Props {
 
 defineProps<Props>();
 
-const breadcrumbs: BreadcrumbItem[] = [
+const breadcrumbItems: BreadcrumbItem[] = [
     {
         title: 'Profile settings',
         href: '/settings/profile',
@@ -41,7 +41,7 @@ const submit = () => {
 </script>
 
 <template>
-    <AppLayout :breadcrumbs="breadcrumbs">
+    <AppLayout :breadcrumbs="breadcrumbItems">
         <Head title="Profile settings" />
 
         <SettingsLayout>


### PR DESCRIPTION
Make `breadcrumbItems` variable name consistent between settings pages (Appearance, Password and Profile)