### PR TITLE
Enhance dynamic page title generation with fallback to app name

### DIFF
--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -11,7 +11,7 @@ createServer((page) =>
     createInertiaApp({
         page,
         render: renderToString,
-        title: (title) => `${title} - ${appName}`,
+        title: (title) => title ? `${title} - ${appName}` : appName,
         resolve: resolvePage,
         setup: ({ App, props, plugin }) =>
             createSSRApp({ render: () => h(App, props) })


### PR DESCRIPTION
Updated the title function to support pages without a custom title.
Now, if no title is provided, it will default to displaying only the appName.
This improves consistency across routes and prevents malformed titles like `- AppName`.

Before:

```ts
title: (title) => `${title} - ${appName}`
```

After:

```ts
title: (title) => title ? `${title} - ${appName}` : appName
```