### PR TITLE
fix: augment 'vue' instead of '@vue/runtime-core'

### DIFF
--- a/resources/js/types/globals.d.ts
+++ b/resources/js/types/globals.d.ts
@@ -17,7 +17,7 @@ declare module '@inertiajs/core' {
     interface PageProps extends InertiaPageProps, AppPageProps {}
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         $inertia: typeof Router;
         $page: Page;

--- a/resources/js/types/ziggy.d.ts
+++ b/resources/js/types/ziggy.d.ts
@@ -4,7 +4,7 @@ declare global {
     let route: typeof route;
 }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
     interface ComponentCustomProperties {
         route: typeof route;
     }


### PR DESCRIPTION
https://vuejs.org/guide/typescript/options-api.html#augmenting-global-properties

Found this out from here: https://github.com/nuxt-modules/i18n/issues/3167#issuecomment-2737143472