### PR TITLE
fix: page.props.ziggy of type unknown in ssr.ts with pnpm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=@inertiajs/core


### PR DESCRIPTION
Solve an issue with Types and pnpm

Before:
<img width="834" alt="Screenshot 2025-06-16 at 2 41 50 PM" src="https://github.com/user-attachments/assets/adee084c-1686-44a3-949e-9889423cb411" />

After:
<img width="751" alt="Screenshot 2025-06-16 at 2 42 40 PM" src="https://github.com/user-attachments/assets/f28873af-159d-41bb-9966-92b480713f57" />
