### PR TITLE
Simplify vite.config.ts by removing the "duplicate" @ alias

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,9 +21,4 @@ export default defineConfig({
             },
         }),
     ],
-    resolve: {
-        alias: {
-            '@': path.resolve(__dirname, './resources/js'),
-        },
-    },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import vue from '@vitejs/plugin-vue';
 import laravel from 'laravel-vite-plugin';
-import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 


### PR DESCRIPTION
I recently learned that the [laravel-vite-plugin](https://github.com/laravel/vite-plugin/blob/1.x/src/index.ts#L122) registers the same @ alias already (https://github.com/laravel/vite-plugin/blob/4a1c05598cc9fd14a26ceb9a125fee17fb828002/src/index.ts#L122) We can omit it in vite.config.ts and simply the config a bit more.