### PR TITLE
Fix: Fix PHPStan error by chaining Stringable methods for email+IP

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -80,6 +80,10 @@ class LoginRequest extends FormRequest
      */
     public function throttleKey(): string
     {
-        return Str::transliterate(Str::lower($this->string('email')).'|'.$this->ip());
+        return $this->string('email')
+            ->lower()
+            ->append('|'.$this->ip())
+            ->transliterate()
+            ->value();
     }
 }


### PR DESCRIPTION
**Problem:**
`$this->string('email')` returns a `Stringable`. In the old code we did:
```php
return Str::transliterate(
    Str::lower($this->string('email')) . '|' . $this->ip()
);
```
By using the `.` operator to append `|{$this->ip()}`, the `Stringable` was immediately cast to a plain string. PHPStan complained because the concatenation happens without casting the `Stringable` object to string.
**Solution:**
We now keep everything as a `Stringable`:
```php
return $this->string('email')
            ->lower()                       // lower-case while still a Stringable
            ->append('|'.$this->ip())      // append the IP without casting
            ->transliterate()              // transliterate on the Stringable
            ->value();                     // finally cast to string
```
This chains all transformations on the `Stringable` object and only converts to a string once, which satisfies PHPStan’s type checks.
