### PR TITLE
Add throttle to authed password routes

### DIFF
--- a/routes/auth.php
+++ b/routes/auth.php
@@ -49,7 +49,8 @@ Route::middleware('auth')->group(function () {
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware('throttle:6,1');
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -13,6 +13,7 @@ Route::middleware('auth')->group(function () {
     Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::get('settings/password', [PasswordController::class, 'edit'])->name('password.edit');
+
     Route::put('settings/password', [PasswordController::class, 'update'])
         ->middleware('throttle:6,1')
         ->name('password.update');

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -13,7 +13,9 @@ Route::middleware('auth')->group(function () {
     Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
     Route::get('settings/password', [PasswordController::class, 'edit'])->name('password.edit');
-    Route::put('settings/password', [PasswordController::class, 'update'])->name('password.update');
+    Route::put('settings/password', [PasswordController::class, 'update'])
+        ->middleware('throttle:6,1')
+        ->name('password.update');
 
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/Appearance');


### PR DESCRIPTION
Following up from https://github.com/laravel/vue-starter-kit/pull/157, fair point that the non-authenticated routes in that PR would throttle via IP, which makes them a risk. The _Confirm Password_ and _Password Change_ routes, on the other hand, are both authenticated so the throttle will work based on the User Identifier instead. 

Rate limiting these routes is important because they are vulnerable to brute-force attacks if a user's session is hijacked. An attacker who gains access to a user account, can brute-force the user's password to bypass the verification step, or change the password entirely. This would bypass any brute-force monitoring or protections present on the login form.

The risk is relatively low, as an attacker would need to have hijacked the user's account, but it's still a weakness that should be patched.