### PR TITLE
Refactor `VerifyEmailController` to use `fulfill()`

### DIFF
--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 
@@ -18,11 +17,7 @@ class VerifyEmailController extends Controller
             return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
         }
 
-        if ($request->user()->markEmailAsVerified()) {
-            /** @var \Illuminate\Contracts\Auth\MustVerifyEmail $user */
-            $user = $request->user();
-            event(new Verified($user));
-        }
+        $request->fulfill();
 
         return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
     }


### PR DESCRIPTION
This pull request refactors the `VerifyEmailController` to utilize the built-in `fulfill()` method provided by `EmailVerificationRequest`.

By replacing the manual email verification logic with a call to `$request->fulfill()`, we align the implementation with Laravel’s internal conventions, improving code readability, maintainability, and reducing redundancy.

**Changes:**

* Replaced manual `hasVerifiedEmail()` check, `markEmailAsVerified()` call, and `Verified` event dispatch with a single `$request->fulfill()` method call.
* Preserved the existing redirect behavior after verification.

**Benefits:**

* Cleaner, more idiomatic Laravel code.
* Leverages framework-provided method designed for this exact purpose.
* Easier future maintenance and consistency with Laravel best practices.
