### PR TITLE
fix bug input focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "TestStartUiKitVueLaravel",
+    "name": "vue-starter-kit",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "vue-starter-kit",
+    "name": "TestStartUiKitVueLaravel",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/components/ui/input/Input.vue
+++ b/resources/js/components/ui/input/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { HTMLAttributes } from 'vue'
+import { HTMLAttributes, ref } from 'vue';
 import { cn } from '@/lib/utils'
 import { useVModel } from '@vueuse/core'
 
@@ -17,10 +17,18 @@ const modelValue = useVModel(props, 'modelValue', emits, {
   passive: true,
   defaultValue: props.defaultValue,
 })
+
+const inputRef = ref<HTMLInputElement | null>(null);
+
+defineExpose({
+    input: inputRef,
+    focus: () => inputRef.value?.focus()
+});
 </script>
 
 <template>
   <input
+    ref="inputRef"
     v-model="modelValue"
     data-slot="input"
     :class="cn(


### PR DESCRIPTION
Hello, I speak a little English, there is a bug when deleting an account. If you enter the password incorrectly, the focus on input does not work and the entire page breaks (navigation stops working until you refresh the page). 

![image](https://github.com/user-attachments/assets/38ddde12-902a-4efa-b8d9-313f47e3e915)

To remedy this, I changed the input component a bit, flipping both the focus method itself and the full input so that developers could use all the methods of the input element