### PR TITLE
Use `vue/server-renderer` instead of `@vue/server-renderer` for SSR

### DIFF
--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -1,6 +1,6 @@
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
-import { renderToString } from '@vue/server-renderer';
+import { renderToString } from 'vue/server-renderer';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createSSRApp, DefineComponent, h } from 'vue';
 import { ZiggyVue } from 'ziggy-js';


### PR DESCRIPTION
As the [laravel/vue-starter-kit](https://github.com/laravel/vue-starter-kit) uses the [Vue](https://www.npmjs.com/package/vue) version higher than 3.2.13, it could access the `vue/server-renderer` directly without needed to install [@vue/server-renderer](https://www.npmjs.com/package/@vue/server-renderer) as stated on their NPM page.