### PR TITLE
fix: add cva in tailwindFunctions for prettier class sorting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,7 @@
     "htmlWhitespaceSensitivity": "css",
     "printWidth": 150,
     "plugins": ["prettier-plugin-organize-imports", "prettier-plugin-tailwindcss"],
-    "tailwindFunctions": ["clsx", "cn"],
+    "tailwindFunctions": ["clsx", "cn", "cva"],
     "tailwindStylesheet": "resources/css/app.css",
     "tabWidth": 4,
     "overrides": [


### PR DESCRIPTION
Prettier sort class inside `class` and `:class` attributes.
In .prettierrc, we have `clsx` and `cn` inside `tailwindFunctions`, but `cva` is missing.
Adding `cva` will sort classes inside those functions too !