### PR TITLE
Update Settings Layout- Remove y spacing and update break for Separator

### DIFF
--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -29,7 +29,7 @@ const currentPath = page.props.ziggy?.location ? new URL(page.props.ziggy.locati
     <div class="px-4 py-6">
         <Heading title="Settings" description="Manage your profile and account settings" />
 
-        <div class="flex flex-col space-y-8 md:space-y-0 lg:flex-row lg:space-y-0 lg:space-x-12">
+        <div class="flex flex-col lg:flex-row lg:space-y-0 lg:space-x-12">
             <aside class="w-full max-w-xl lg:w-48">
                 <nav class="flex flex-col space-y-1 space-x-0">
                     <Button
@@ -46,7 +46,7 @@ const currentPath = page.props.ziggy?.location ? new URL(page.props.ziggy.locati
                 </nav>
             </aside>
 
-            <Separator class="my-6 md:hidden" />
+            <Separator class="my-6 lg:hidden" />
 
             <div class="flex-1 md:max-w-2xl">
                 <section class="max-w-xl space-y-12">

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -29,7 +29,7 @@ const currentPath = page.props.ziggy?.location ? new URL(page.props.ziggy.locati
     <div class="px-4 py-6">
         <Heading title="Settings" description="Manage your profile and account settings" />
 
-        <div class="flex flex-col lg:flex-row lg:space-y-0 lg:space-x-12">
+        <div class="flex flex-col lg:flex-row lg:space-x-12">
             <aside class="w-full max-w-xl lg:w-48">
                 <nav class="flex flex-col space-y-1 space-x-0">
                     <Button


### PR DESCRIPTION
The space-y was not necessary on smaller screens since we are using a Separator component. I also updated the separator to hide on lg and above since the container element changes to flex row at that breakpoint.

## Before 
<img width="2465" height="1518" alt="Profile-settings-Laravel-07-16-2025_06_45_PM" src="https://github.com/user-attachments/assets/1dfc050d-21e4-422c-9f60-bac4332d9eec" />
<img width="1835" height="1518" alt="Profile-settings-Laravel-07-16-2025_06_46_PM" src="https://github.com/user-attachments/assets/cd20e8fe-19b4-4d0d-bfa2-2be0f2052bed" />

## After Updates
<img width="2395" height="1518" alt="Profile-settings-Laravel-07-16-2025_06_43_PM" src="https://github.com/user-attachments/assets/39619fec-c564-48b1-9fed-a710f846074f" />
<img width="1535" height="1518" alt="Profile-settings-Laravel-07-16-2025_06_44_PM" src="https://github.com/user-attachments/assets/de744330-e38c-4d42-b641-672463f2f6b1" />
