### PR TITLE
Use `tsx` flag instead of `typescript`

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://shadcn-vue.com/schema.json",
     "style": "default",
-    "typescript": true,
+    "tsx": true,
     "tailwind": {
         "config": "tailwind.config.js",
         "css": "resources/css/app.css",


### PR DESCRIPTION
The Laravel Starter Kit’s components.json schema has been updated to replace the unrecognised `typescript` key with `tsx`, aligning with shadcn UI’s expected configuration.

https://ui.shadcn.com/docs/components-json#tsx

Furthermore, this key/value pair does not exist in the shadcn/vue fork.

Currently when attempting to configure extensions for shadcn/ui shadcn/vue if this line exists it breaks CLI functionality.

This fix ensures that third‑party shadcn plugins and the shadcn CLI
correctly detect and generate TSX components.
