### PR TITLE
Remove TSX from components.json

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,7 +1,6 @@
 {
     "$schema": "https://shadcn-vue.com/schema.json",
     "style": "default",
-    "tsx": true,
     "tailwind": {
         "config": "tailwind.config.js",
         "css": "resources/css/app.css",


### PR DESCRIPTION
As @patrickdundas highlighted in [#166](https://github.com/laravel/vue-starter-kit/pull/166), the transition from `typescript` to `tsx` in the vue-starter-kit has introduced an issue that breaks the ability to add components via the CLI.

Upon further investigation, @patrickdundas found that the root of the issue lies in how components.json is handled differently between the shadcn and shadcn-vue packages:

shadcn-vue defaults to using `typescript` in its schema.

shadcn, on the other hand, defaults to `tsx`.

When reverting the `tsx` setting back to the `typescript` and setting it to true, component generation works as expected, but not for 3rd party plugins. However, if you then attempt to set typescript to false, it breaks the generation process again.

This makes the setting somewhat redundant, as both `tsx` and `typescript` are enabled by default, and neither can reliably be set to false without causing issues.

Removing the explicit line for typescript (`tsx`) resolves the incompatibility between the two schema implementations and restores full CLI support for component generation, including compatibility with third-party plugins.

This change ensures consistency and prevents unexpected behaviour regardless of which underlying schema is used.