### PR TITLE
Standardise function usage

### DIFF
--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -12,7 +12,7 @@ createServer((page) =>
         page,
         render: renderToString,
         title: (title) => title ? `${title} - ${appName}` : appName,
-        resolve: resolvePage,
+        resolve: (name) => resolvePageComponent(`./pages/${name}.vue`, import.meta.glob<DefineComponent>('./pages/**/*.vue')),
         setup: ({ App, props, plugin }) =>
             createSSRApp({ render: () => h(App, props) })
                 .use(plugin)
@@ -23,9 +23,3 @@ createServer((page) =>
     }),
     { cluster: true },
 );
-
-function resolvePage(name: string) {
-    const pages = import.meta.glob<DefineComponent>('./pages/**/*.vue');
-
-    return resolvePageComponent<DefineComponent>(`./pages/${name}.vue`, pages);
-}


### PR DESCRIPTION
I noticed that across all our starter kits, old and new, the SSR bootstrap file was the only place that had an extracted method for the resolve function.

This aligns the function logic across starter kits and also within this repo itself, as this now aligns with the `app.ts` bootstrap function.