### PR TITLE
test: Add missing feature tests to ensure 100% coverage in starter kit

### DIFF
--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -55,4 +55,53 @@ class EmailVerificationTest extends TestCase
 
         $this->assertFalse($user->fresh()->hasVerifiedEmail());
     }
+
+    public function test_email_is_not_verified_with_invalid_user_id(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+        ]);
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => 123, 'hash' => sha1($user->email)]
+        );
+
+        $this->actingAs($user)->get($verificationUrl);
+
+        $this->assertFalse($user->fresh()->hasVerifiedEmail());
+    }
+
+    public function test_verified_user_is_redirected_to_dashboard_from_verification_prompt(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user)->get('/verify-email');
+
+        $response->assertRedirect(route('dashboard', absolute: false));
+    }
+
+    public function test_already_verified_user_visiting_verification_link_is_redirected_without_firing_event_again(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        Event::fake();
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $this->actingAs($user)->get($verificationUrl)
+            ->assertRedirect(route('dashboard', absolute: false).'?verified=1');
+
+        $this->assertTrue($user->fresh()->hasVerifiedEmail());
+        Event::assertNotDispatched(Verified::class);
+    }
 }

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -70,4 +70,18 @@ class PasswordResetTest extends TestCase
             return true;
         });
     }
+
+    public function test_password_cannot_be_reset_with_invalid_token(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->post('/reset-password', [
+            'token' => 'invalid-token',
+            'email' => $user->email,
+            'password' => 'newpassword123',
+            'password_confirmation' => 'newpassword123',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+    }
 }

--- a/tests/Feature/Auth/VerificationNotificationTest.php
+++ b/tests/Feature/Auth/VerificationNotificationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class VerificationNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sends_verification_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email_verified_at' => null,
+        ]);
+
+        $this->actingAs($user)
+            ->post('email/verification-notification')
+            ->assertRedirect('/');
+
+        Notification::assertSentTo($user, VerifyEmail::class);
+    }
+
+    public function test_does_not_send_verification_notification_if_email_is_verified(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->post('email/verification-notification')
+            ->assertRedirect(route('dashboard', absolute: false));
+
+        Notification::assertNothingSent();
+    }
+}

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -11,6 +11,17 @@ class PasswordUpdateTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_password_update_page_is_displayed()
+    {
+        $user = User::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->get('/settings/password');
+
+        $response->assertStatus(200);
+    }
+
     public function test_password_can_be_updated()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
This PR adds feature tests that were previously untested in the starter kit. With these additions, a freshly generated application now reaches **100% test coverage** out of the box. For example, if someone run pest with 100% coverage:

```bash
pest --parallel --coverage --exactly=100
```

will pass successfully on a clean install. This means developers start with full coverage by default, without having to write additional tests themselves.

Not everyone needs 100% coverage for their project, but having it baked into the starter kit provides a solid foundation to build from. Teams can then decide whether to maintain this level or adjust it to match their specific requirements.

## Changes

The following authentication and verification scenarios are now covered by tests:

* Users are rate limited after multiple failed login attempts.
* An invalid user ID does not mark the email as verified.
* Verified users visiting the email verification prompt are redirected to the dashboard.
* Already verified users visiting the verification link are redirected without triggering the verification event again.
* Password reset is rejected when using an invalid token.
* A verification notification is sent to users who are not yet verified.
* No verification notification is sent if the user's email is already verified.
* The password update page is displayed correctly.

## Notes

* The starter kit uses **PHPUnit** as its base testing suite, so the new tests are written in PHPUnit and all pass successfully.
* I'm not sure if the installer automatically translates these PHPUnit tests into Pest when Pest is selected during installation, or if they should be duplicated/updated in a Pest-specific location. I’d appreciate guidance on this point.