### PR TITLE
Refactor urlIsActive function to improve URL matching logic

### DIFF
--- a/resources/js/lib/utils.ts
+++ b/resources/js/lib/utils.ts
@@ -7,7 +7,17 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function urlIsActive(urlToCheck: NonNullable<InertiaLinkProps['href']>, currentUrl: string) {
-    return toUrl(urlToCheck) === currentUrl;
+    const checkUrl = toUrl(urlToCheck);
+
+    if (checkUrl === '/' && currentUrl === '/') {
+        return true;
+    }
+
+    if (checkUrl !== '/' && currentUrl.startsWith(checkUrl)) {
+        return true;
+    }
+
+    return false;
 }
 
 export function toUrl(href: NonNullable<InertiaLinkProps['href']>) {


### PR DESCRIPTION
This pull request updates the logic for checking if a URL is active in the `urlIsActive` utility function to provide more accurate matching, especially for root and subpath URLs.

Navigation logic improvements:

* Updated the `urlIsActive` function in `resources/js/lib/utils.ts` to ensure that the root path `'/'` only matches itself, and that non-root paths match if the current URL starts with the checked URL. This provides more intuitive active link highlighting for navigation.
* Usefull for the nav bar, because we want to keep the nav bar active in many route in a CRUD, example /admin/users, /admin/users/create, /admin/users/1/edit, etc.