### PR TITLE
Correct LoginRequest retrieved user type to allow null

### DIFF
--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -41,7 +41,7 @@ class LoginRequest extends FormRequest
     {
         $this->ensureIsNotRateLimited();
 
-        /** @var User $user */
+        /** @var User|null $user */
         $user = Auth::getProvider()->retrieveByCredentials($this->only('email', 'password'));
 
         if (! $user || ! Auth::getProvider()->validateCredentials($user, $this->only('password'))) {


### PR DESCRIPTION
The issue was caused by a too-strict PHPDoc that assumed the retrieved user is always a User. However, `retrieveByCredentials()` can return null. 

This aligns the docblock with the actual return type, making the subsequent null/credential checks type-safe.