### PR TITLE
Feature/accessibility improvements

### DIFF
--- a/resources/js/components/AppContent.vue
+++ b/resources/js/components/AppContent.vue
@@ -17,6 +17,7 @@ const className = computed(() => props.class);
     </SidebarInset>
     <main
         v-else
+        id="main"
         class="mx-auto flex h-full w-full max-w-7xl flex-1 flex-col gap-4 rounded-xl"
         :class="className"
     >

--- a/resources/js/components/AppSkipLink.vue
+++ b/resources/js/components/AppSkipLink.vue
@@ -1,0 +1,9 @@
+<template>
+    <a
+        href="#main"
+        class="absolute -top-14 left-4 z-[100] rounded-md bg-black px-4 py-2 text-sm font-semibold text-white shadow-lg transition-all duration-300 ease-in-out focus:top-2 focus:outline-2 focus:ring-primary-500 focus:outline-offset-4 dark:bg-primary dark:text-black dark:focus:outline-sidebar-ring motion-reduce:transition-none"
+    >
+        Skip to Main Content
+    </a>
+</template>
+

--- a/resources/js/components/ui/sidebar/SidebarInset.vue
+++ b/resources/js/components/ui/sidebar/SidebarInset.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
 
 <template>
   <main
+    id="main"
     data-slot="sidebar-inset"
     :class="cn(
       'bg-background relative flex w-full flex-1 flex-col',

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/app/AppSidebarLayout.vue';
+import AppSkipLink from '@/components/AppSkipLink.vue';
 import type { BreadcrumbItemType } from '@/types';
 
 interface Props {
@@ -12,6 +13,7 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
+    <AppSkipLink />
     <AppLayout :breadcrumbs="breadcrumbs">
         <slot />
     </AppLayout>

--- a/resources/js/layouts/settings/Layout.vue
+++ b/resources/js/layouts/settings/Layout.vue
@@ -41,7 +41,7 @@ const currentPath = typeof window !== undefined ? window.location.pathname : '';
 
         <div class="flex flex-col lg:flex-row lg:space-x-12">
             <aside class="w-full max-w-xl lg:w-48">
-                <nav class="flex flex-col space-y-1 space-x-0">
+                <nav class="flex flex-col space-y-1 space-x-0" aria-label="Settings">
                     <Button
                         v-for="item in sidebarNavItems"
                         :key="toUrl(item.href)"

--- a/resources/js/pages/settings/Appearance.vue
+++ b/resources/js/pages/settings/Appearance.vue
@@ -21,6 +21,8 @@ const breadcrumbItems: BreadcrumbItem[] = [
     <AppLayout :breadcrumbs="breadcrumbItems">
         <Head title="Appearance settings" />
 
+        <h1 class="sr-only">Appearance Settings</h1>
+
         <SettingsLayout>
             <div class="space-y-6">
                 <HeadingSmall

--- a/resources/js/pages/settings/Password.vue
+++ b/resources/js/pages/settings/Password.vue
@@ -28,6 +28,8 @@ const currentPasswordInput = ref<HTMLInputElement | null>(null);
     <AppLayout :breadcrumbs="breadcrumbItems">
         <Head title="Password settings" />
 
+        <h1 class="sr-only">Password Settings</h1>
+
         <SettingsLayout>
             <div class="space-y-6">
                 <HeadingSmall

--- a/resources/js/pages/settings/Profile.vue
+++ b/resources/js/pages/settings/Profile.vue
@@ -36,6 +36,8 @@ const user = page.props.auth.user;
     <AppLayout :breadcrumbs="breadcrumbItems">
         <Head title="Profile settings" />
 
+        <h1 class="sr-only">Profile Settings</h1>
+
         <SettingsLayout>
             <div class="flex flex-col space-y-6">
                 <HeadingSmall

--- a/resources/js/pages/settings/TwoFactor.vue
+++ b/resources/js/pages/settings/TwoFactor.vue
@@ -41,6 +41,9 @@ onUnmounted(() => {
 <template>
     <AppLayout :breadcrumbs="breadcrumbs">
         <Head title="Two-Factor Authentication" />
+
+        <h1 class="sr-only">Two-Factor Authentication Settings</h1>
+
         <SettingsLayout>
             <div class="space-y-6">
                 <HeadingSmall


### PR DESCRIPTION
# Accessibility Improvements

## Description

This PR makes the following accessibility improvements to the dashboard:

- It adds a skip link in order to satisfy [WCAG Success Criterion 2.4.1 Bypass Blocks](https://www.w3.org/TR/WCAG21/#bypass-blocks).
  - It's worth noting that the skip link styling intentionally utilizes Tailwind's `outline` classes rather than `ring` classes because the `ring` classes rely on box shadows, and box shadows are removed in Windows High Contrast Mode (which would result in focus indicators no longer being visible in WHCM).
- It adds `sr-only` `<h1>` elements to each of the 4 settings pages, so as to ensure that heading levels aren't skipped and each of the settings pages provides a main heading to screen readers.
- It adds an ARIA label to the settings sub-navigation menu so as to provide better context for screen reader users.

## Screenshots

### Skip Link -- Light Mode

<img width="614" height="215" alt="Skip Link -- Light Mode" src="https://github.com/user-attachments/assets/16135847-6122-4e81-930d-a964acf28ec5" />

### Skip Link -- Dark Mode

<img width="589" height="219" alt="Skip Link -- Dark Mode" src="https://github.com/user-attachments/assets/fcf57dec-01f3-4d78-8730-e8901c3a0c95" />

### VoiceOver Headings List -- Profile Settings Page

<img width="634" height="245" alt="Profile Settings Page Headings" src="https://github.com/user-attachments/assets/b7e8353c-2c16-4565-97a7-c1e4d2b67bd0" />

### VoiceOver Headings List -- Password Settings Page

<img width="634" height="215" alt="Password Settings Page Headings" src="https://github.com/user-attachments/assets/610622fa-21c6-44b6-abe6-6381547d0d24" />

### VoiceOver Headings List -- Two-Factor Authentication Page

<img width="634" height="215" alt="Two-Factor Authentication Page Headings" src="https://github.com/user-attachments/assets/0e13ad73-4160-45ea-ad96-2682e303c13b" />

### VoiceOver Headings List -- Appearance Settings Page

<img width="634" height="215" alt="Appearance Settings Page Headings" src="https://github.com/user-attachments/assets/72add179-b399-418b-88d1-12cc1daddee7" />

### Settings Navigation ARIA Label

<img width="634" height="245" alt="Settings Navigation ARIA Label" src="https://github.com/user-attachments/assets/89eb09f8-a238-470f-91b0-deb6219838d1" />

## Screencast of Skip Link in Action

**Note**: As demonstrated in this screencast, the skip link, when used, will skip repetitive navigation (e.g., the sidebar navigation) and move keyboard focus to the main content of the page. It will also respect reduced motion preferences that are set at the OS level (i.e., the transition will be removed if the user has reduced motion preferences set).

https://github.com/user-attachments/assets/92051167-caf7-4a8d-8cd6-c616628decb5